### PR TITLE
Trailing slashes in target of dojo.store.JsonStore (Issue #16691)

### DIFF
--- a/store/JsonRest.js
+++ b/store/JsonRest.js
@@ -68,7 +68,7 @@ return declare("dojo.store.JsonRest", base, {
     options = options || {};
     var target = this.target;
     if (typeof id != "undefined"){
-      if (target.match(/\/$/)){
+      if (target.charAt(target.length-1) == '/'){
          target += id;
       }else{
         target += '/' + id;


### PR DESCRIPTION
Fixes issue #16691

Added property `allowNoTrailingSlash` to control the behaviour. Default is false.
If false, the previous behaviour is used, i.e. a trailing slash on `target` is expected.
If true, `target` is checked for a trailing slash. If none exists, then a slash appended to `target`
If options.before is set and contains an id, then this id is also appended to the target URL.
