### PR TITLE
workaround a BB10 JavaScript VM bug by doing forEach differently, refs #17204

### DIFF
--- a/dojo.js
+++ b/dojo.js
@@ -89,7 +89,7 @@
 
 		forEach = function(vector, callback){
 			if(vector){
-				for(var i = 0; vector[i];){
+				for(var i = 0; i < vector.length;){
 					callback(vector[i++]);
 				}
 			}


### PR DESCRIPTION
This pull request is to workaround a BB10 JavaScript VM bug that is hurting dojox/app and in some cases dojox/mobile (and probably others).

The workaround is not a strict equivalent of the current code because it stops iterating at the end of the array while the previous code was stopping iterating at the first undefined value. We could probably make it behaves exactly the same (by adding a conditional test) while still not hurting the VM bug but honestly I'm not sure it worths it as the only cases were would face that would be with sparse require array which I don't think we are supposed to support anyway:

``` javascript
require(["A", , "B"], function(){});
```
