### PR TITLE
[cla] Fix #13561: gotoPercent has no effect on fx.chain

### DIFF
--- a/fx.js
+++ b/fx.js
@@ -105,18 +105,18 @@ define([
 		},
 		gotoPercent: function(/*Decimal*/percent, /*Boolean?*/ andPlay){
 			this.pause();
-			var offset = this.duration * percent,
-				self = this;
+			var offset = this.duration * percent;
 			this._current = null;
+
 			arrayUtil.some(this._animations, function(a, index){
 				if(offset <= a.duration){
-					self._current = a;
-					self._index = index;
+					this._current = a;
+					this._index = index;
 					return true;
 				}
 				offset -= a.duration;
 				return false;
-			});
+			}, this);
 			if(this._current){
 				this._current.gotoPercent(offset / this._current.duration);
 			}

--- a/tests/fx.html
+++ b/tests/fx.html
@@ -86,6 +86,41 @@
 						},
 						
 						{
+							name: "gotoPercent Chain",
+							timeout: 2000,
+							runTest: function (t) {
+								var d = new doh.Deferred(),
+									node = dom.byId('baz'),
+									anims = [
+										baseFx.fadeOut({node:node}),
+										baseFx.fadeIn({node:node}),
+										fx.wipeOut({node:node}),
+										fx.wipeIn({node:node}),
+										fx.slideTo({node:node,top:200,left:300})
+									],
+									chain = fx.chain(anims),
+									len = anims.length,
+									percent = 0.34,
+									totalActive = len - Math.floor(percent * len),
+									numRun = 0;
+
+								array.forEach(anims, function (anim, index) {
+									aspect.before(anim, 'onEnd', function () {
+										numRun++;
+									});
+								});
+
+								aspect.after(chain, 'onEnd', function () {
+									doh.t(totalActive === numRun);
+									d.callback(true);
+								});
+
+								chain.gotoPercent(percent, true);
+								return d;
+							}
+						},
+
+						{
 							name: "combine",
 							timeout: 1500,
 							runTest: function(t){
@@ -484,6 +519,7 @@
 		</div>
 		
 		<p id="a1">p</p><p id="a2">p</p>
+		<div id="baz">baz</div>
 		
 	</body>
 </html>


### PR DESCRIPTION
Corresponding Dojo ticket: https://bugs.dojotoolkit.org/ticket/13561

Fix for an animation chain's gotoPercent
- fix incorrect `this` reference in `some` callback
- reverse animation duration and offset check
- update the index to the current animation once found
- call gotoPercent on individual animation, but do not pass andPlay flag
- if andPlay, then call play on this chain
