### PR TITLE
Proposed fix for trac ticket #17155

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -146,6 +146,7 @@ define(["./_base/kernel", "require", "./has", "./_base/array", "./_base/config",
 		getLocalesToLoad = function(targetLocale){
 			var list = config.extraLocale || [];
 			list = lang.isArray(list) ? list : [list];
+			list = array.map(list, getMatchedLocale);
 			list.push(targetLocale);
 			return list;
 		},


### PR DESCRIPTION
This is a two parts fix, one in dojo/i18n, one in util/build/tranforms/writeAMD.

The idea is to gather a list of all available locales in the application at build time, so the i18n plugin can decide of the best available locale without doing any http request.

There is two other pull requests for 1.8 branch to account for the different code base.
