### PR TITLE
refs #17651, make router.destroy fail safely if router.startup has not b...

### DIFF
--- a/router/RouterBase.js
+++ b/router/RouterBase.js
@@ -220,7 +220,9 @@ define([
 		},
 
 		destroy: function(){
-			this._hashchangeHandle.remove();
+			if(this._hashchangeHandle){
+				this._hashchangeHandle.remove();
+			} 			
 			this._routes = null;
 			this._routeIndex = null;
 		},


### PR DESCRIPTION
...een called.

This seems like the most direct option, but another option could be to check if this._started has been set.
