### PR TITLE
re-usable text escaping

### DIFF
--- a/string.js
+++ b/string.js
@@ -5,12 +5,31 @@ define([
 
 // module:
 //		dojo/string
-
+var ESCAPE_REGEXP = /[&<>'"\/]/g;
+var ESCAPE_MAP = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	"'": '&#x27;',
+	'/': '&#x2F;'
+};
 var string = {
 	// summary:
 	//		String utilities for Dojo
 };
 lang.setObject("dojo.string", string);
+
+string.escape = function(/*String*/str){
+	// summary:
+	//		Efficiently escape a string for insertion into HTML (innerHTML or attributes), replacing &, <, >, ", ', and / characters.
+	// str:
+	//		the string to escape
+	if(!str){ return ""; }
+	return str.replace(ESCAPE_REGEXP, function(c) {
+		return ESCAPE_MAP[c];
+	});
+};
 
 string.rep = function(/*String*/str, /*Integer*/num){
 	// summary:

--- a/tests/string.js
+++ b/tests/string.js
@@ -85,6 +85,12 @@ doh.register("tests.string",
 			t.is("abababab", string.rep("ab", 4));
 			t.is("", string.rep("ab", 0));
 			t.is("", string.rep("", 3));
+		},
+		
+		function test_string_escape(t){
+			t.is("astoria", string.escape("astoria"));
+			t.is("&amp;&lt;&gt;&#x27;&#x2F;", string.escape("&<>'/"));
+			t.is('oh&quot;oh&quot;oh', string.escape('oh"oh"oh'));
 		}
 	]
 );


### PR DESCRIPTION
See https://bugs.dojotoolkit.org/ticket/8995

I made the choice to use a regexp instead of createTextNode because it really faster
