### PR TITLE
Use Element.matches if available

### DIFF
--- a/selector/lite.js
+++ b/selector/lite.js
@@ -2,7 +2,7 @@ define(["../has", "../_base/kernel"], function(has, dojo){
 "use strict";
 
 var testDiv = document.createElement("div");
-var matchesSelector = testDiv.matchesSelector || testDiv.webkitMatchesSelector || testDiv.mozMatchesSelector || testDiv.msMatchesSelector || testDiv.oMatchesSelector; // IE9, WebKit, Firefox have this, but not Opera yet
+var matchesSelector = testDiv.matches || testDiv.webkitMatchesSelector || testDiv.mozMatchesSelector || testDiv.msMatchesSelector || testDiv.oMatchesSelector;
 var querySelectorAll = testDiv.querySelectorAll;
 var unionSplit = /([^\s,](?:"(?:\\.|[^"])+"|'(?:\\.|[^'])+'|[^,])*)/g;
 has.add("dom-matches-selector", !!matchesSelector);


### PR DESCRIPTION
Spec:
http://dom.spec.whatwg.org/#dom-element-matches

Support in Chromium:
https://code.google.com/p/chromium/issues/detail?id=326652

Element.matchesSelector was never standardized and it is not available
in the most recent versions of Blink, Gecko, Presto, Trident or WebKit.

Remove the trailing comment since it had become stale. Opera 12.16
(Presto) did have oMatchesSelector and since Opera 14 (Blink) it has
webkitMatchesSelector instead.
