### PR TITLE
Fix #16296 console.debug(NaN) produces error in IE9

### DIFF
--- a/_base/kernel.js
+++ b/_base/kernel.js
@@ -164,7 +164,7 @@ define(["../has", "./config", "require", "module"], function(has, config, requir
 				(function(){
 					var tcn = tn + "";
 					console[tcn] = ('log' in console) ? function(){
-						var a = Array.apply({}, arguments);
+						var a = Array.prototype.slice.call(arguments);
 						a.unshift(tcn + ":");
 						console["log"](a.join(" "));
 					} : function(){};


### PR DESCRIPTION
Properly convert arguments to an array when shimming a console function.
