### PR TITLE
[CLA] Avoid iOS body scroll reset in dojo/window.scrollIntoView, fixes #17740

### DIFF
--- a/window.js
+++ b/window.js
@@ -148,6 +148,15 @@ define(["./_base/lang", "./sniff", "./_base/window", "./dom", "./dom-geometry", 
 						return (isIE <= 6 || (isIE == 7 && backCompat))
 							? false
 							: (has("position-fixed-support") && (style.get(el, 'position').toLowerCase() == "fixed"));
+					},
+					self = this,
+					scrollElementBy = function(el, x, y){
+						if(el.tagName == "BODY" || el.tagName == "HTML"){
+							self.get(el.ownerDocument).scrollBy(x, y);
+						}else{
+							x && (el.scrollLeft += x);
+							y && (el.scrollTop += y);
+						}
 					};
 				if(isFixed(node)){ return; } // nothing to do
 				while(el){
@@ -203,14 +212,14 @@ define(["./_base/lang", "./sniff", "./_base/window", "./dom", "./dom-geometry", 
 						s = Math[l < 0? "max" : "min"](l, r);
 						if(rtl && ((isIE == 8 && !backCompat) || isIE >= 9)){ s = -s; }
 						old = el.scrollLeft;
-						el.scrollLeft += s;
+						scrollElementBy(el, s, 0);
 						s = el.scrollLeft - old;
 						nodePos.x -= s;
 					}
 					if(bot * t > 0 && (!!el.scrollTop || el == scrollRoot || el.scrollHeight > el.offsetHeight)){
 						s = Math.ceil(Math[t < 0? "max" : "min"](t, bot));
 						old = el.scrollTop;
-						el.scrollTop += s;
+						scrollElementBy(el, 0, s);
 						s = el.scrollTop - old;
 						nodePos.y -= s;
 					}


### PR DESCRIPTION
This PR updates `dojo/window.scrollIntoView` to scroll the body in a way that avoids an iOS issue with resetting `body.scrollLeft` when `body.scrollTop` is set and vice versa.

I looked at adding a unit test for this, but the dojo/window tests are already failing on iOS, and I don't have time to address them. However, I hope to update them as part of the doh-to-intern conversion. Maybe something can be done then.

I ran the dojo package's test suite in the following environments to verify that this fix did not cause test failures (or additional failures in environments already experiencing failures on dojo `master`):
- Win7 + IE8,9,10 
- Win7 + Chrome latest
- Win7 + FF latest and latest FF ESR
- Win8 + IE11
- OSX + Safari 6.1
- OSX + Chrome latest
- OSX + Firefox latest
- Arch Linux + Chromium latest
- Arch Linux + Firefox latest
