### PR TITLE
refs #15246 cache ActiveX constructor.

### DIFF
--- a/request/handlers.js
+++ b/request/handlers.js
@@ -30,7 +30,7 @@ define([
 				// IE9 supports a CSS3 querySelectorAll implementation, but the DOM implementation
 				// returned by IE9 xhr.responseXML does not. Manually create the XML DOM to gain
 				// the fuller-featured implementation and avoid bugs caused by the inconsistency
-				result = new DOMParser().parseFromString(response.text, 'application/xml');
+				result = new DOMParser().parseFromString(text, 'application/xml');
 			}
 
 			function createDocument(p) {
@@ -45,9 +45,14 @@ define([
 			}
 
 			if(!result || !result.documentElement){
-				//try to use the cached parser
+				// The creation of an ActiveX object is expensive, we want to cache the
+				// parser type to avoid trying all parser types each time we handle a
+				// document. There is some concern that some parser types might fail
+				// depending on the document being parsed. If parsing using the cached
+				// parser type fails, we do the more expensive operation of finding one
+				// which will work for the given document.
+				// https://bugs.dojotoolkit.org/ticket/15246
 				if(!lastParser || !createDocument(lastParser)) {
-					//find one that works
 					array.some(dp, createDocument);
 				}
 			}


### PR DESCRIPTION
Cache the document parser type to improver performance. If the cached parser fails resume search for a compatible parser.

[refs 15246](https://bugs.dojotoolkit.org/ticket/15246) 
