### PR TITLE
fixes #17828 (branch 1.9) dojox/mobile: click events miss most properties.

### DIFF
--- a/tests/test_touch.html
+++ b/tests/test_touch.html
@@ -10,6 +10,8 @@
 				height: 150px;
 				border: 1px solid #7FB0DB;
 				background-color: #7FB0DB;
+				touch-action: none;
+				-ms-touch-action: none;
 			}
 			#innertest {
 				border: 1px solid white;
@@ -23,21 +25,27 @@
 				height: 50px;
 				border: 1px solid yellow;
 				background-color: yellow;
+				touch-action: none;
+				-ms-touch-action: none;
 			}
 			#test3 {
 				width: 300px;
 				height: 150px;
 				border: 1px solid red;
-				background-color: red;      
+				background-color: red;
+				touch-action: none;
+				-ms-touch-action: none;
 			}
 			#innertest3 {
 				border: 1px solid white;
 				width: 250px;
 				height: 75px;
 				background-color: white;
+				touch-action: none;
+				-ms-touch-action: none;
 			}
 			#current, #log {
-				width: 300px;
+				width: 50%;
 				height: 200px;
 				float: left;
 			}
@@ -122,9 +130,23 @@
 //					on(node, "touchcancel", action);
 //					on(node, "orientationchange", action);
 
+				function logClickEvent(e) {
+					// synthetic click has _dojo_click = true
+					dom.byId("log").innerHTML = " - _dojo_click [" + e._dojo_click + "]<br/>" + dom.byId("log").innerHTML;
+					// display mouse event attributes
+					// http://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-eventgroupings-mouseevents
+					var info = "",
+							mouseEventAttrNames = ["screenX", "screenY", "clientX", "clientY", "ctrlKey", "altKey", "shiftKey", "metaKey", "button"];
+					for (var attrIdx = 0, name; attrIdx < mouseEventAttrNames.length && (name = mouseEventAttrNames[attrIdx]); attrIdx++) {
+						info += " - " + name + " [" + e[name] + "]<br/>";
+					}
+					dom.byId("log").innerHTML = info + dom.byId("log").innerHTML;
+				}
+				
 				dom.byId("test3").dojoClick = true;
 				on(dom.byId("test3"), "click", function(e){
-					if(has("touch")){
+					logClickEvent(e);
+					if(has("touch") || navigator.maxTouchPoints){
 						// click should be a synthetic click
 						dom.byId("log").innerHTML = (e._dojo_click ? "Synthetic click received in test3" : "ERROR: native click received in test3") + "<br/>" + dom.byId("log").innerHTML;
 					}else{
@@ -134,6 +156,7 @@
 				});
 				dom.byId("innertest3").dojoClick = false;
 				on(dom.byId("innertest3"), "click", function(e){
+					logClickEvent(e);
 					// click should be a native click
 					dom.byId("log").innerHTML = (e._dojo_click ? "ERROR: Synthetic click received in innertest3" : "Native click received in innertest3") + "<br/>" + dom.byId("log").innerHTML;;
 					e.stopPropagation();

--- a/touch.js
+++ b/touch.js
@@ -76,8 +76,8 @@ function(dojo, aspect, dom, domClass, lang, on, has, mouse, domReady, win){
 		clickTracker  = !e.target.disabled && marked(e.target); // click threshold = true, number or x/y object
 		if(clickTracker){
 			clickTarget = e.target;
-			clickX = e.touches ? e.touches[0].pageX : e.clientX;
-			clickY = e.touches ? e.touches[0].pageY : e.clientY;
+			clickX = e.changedTouches ? e.changedTouches[0].pageX : e.clientX;
+			clickY = e.changedTouches ? e.changedTouches[0].pageY : e.clientY;
 			clickDx = (typeof clickTracker == "object" ? clickTracker.x : (typeof clickTracker == "number" ? clickTracker : 0)) || 4;
 			clickDy = (typeof clickTracker == "object" ? clickTracker.y : (typeof clickTracker == "number" ? clickTracker : 0)) || 4;
 
@@ -88,9 +88,9 @@ function(dojo, aspect, dom, domClass, lang, on, has, mouse, domReady, win){
 
 				win.doc.addEventListener(moveType, function(e){
 					clickTracker = clickTracker &&
-						e.target == clickTarget &&
-						Math.abs((e.touches ? e.touches[0].pageX : e.clientX) - clickX) <= clickDx &&
-						Math.abs((e.touches ? e.touches[0].pageY : e.clientY) - clickY) <= clickDy;
+						(e.changedTouches ? e.changedTouches[0].target : e.target) == clickTarget &&
+						Math.abs((e.changedTouches ? e.changedTouches[0].pageX : e.clientX) - clickX) <= clickDx &&
+						Math.abs((e.changedTouches ? e.changedTouches[0].pageY : e.clientY) - clickY) <= clickDy;
 				}, true);
 
 				win.doc.addEventListener(endType, function(e){
@@ -101,13 +101,32 @@ function(dojo, aspect, dom, domClass, lang, on, has, mouse, domReady, win){
 							// when clicking on a label, forward click to its associated input if any
 							target = dom.byId(target.getAttribute("for")) || target;
 						}
+						//some attributes can be on the Touch object, not on the Event:
+						//http://www.w3.org/TR/touch-events/#touch-interface
+						var src = (e.changedTouches) ? e.changedTouches[0] : e;
+						//create the synthetic event.
+						//http://www.w3.org/TR/DOM-Level-3-Events/#widl-MouseEvent-initMouseEvent
+						var clickEvt = document.createEvent("MouseEvents");
+						clickEvt._dojo_click = true;
+						clickEvt.initMouseEvent("click",
+							true, //bubbles
+							true, //cancelable
+							e.view,
+							e.detail,
+							src.screenX,
+							src.screenY,
+							src.clientX,
+							src.clientY,
+							e.ctrlKey,
+							e.altKey,
+							e.shiftKey,
+							e.metaKey,
+							0, //button
+							null //related target
+						);
 						setTimeout(function(){
-							on.emit(target, "click", {
-								bubbles : true,
-								cancelable : true,
-								_dojo_click : true
-							});
-						});
+							on.emit(target, "click", clickEvt);
+						}, 0);
 					}
 				}, true);
 


### PR DESCRIPTION
(such as pageX, clientX, screenX...) on touch devices/webkit browsers.
