### PR TITLE
fix native-formdata has detection on ios 6, fixes #16022

### DIFF
--- a/request/xhr.js
+++ b/request/xhr.js
@@ -24,7 +24,7 @@ define([
 
 	has.add('native-formdata', function(){
 		// if true, the environment has a native FormData implementation
-		return typeof FormData === 'function';
+		return typeof FormData !== 'undefined';
 	});
 
 	function handleResponse(response, error){


### PR DESCRIPTION
This PR addresses the has("native-formdata") test that is wrong on iOS 6. Indeed, on this platform, `typeof FormData` is `object`, not function. (see https://bugs.dojotoolkit.org/ticket/16022.)

There's no testcase attached as the [tests/request/xhr.html](https://github.com/dojo/dojo/blob/master/tests/request/xhr.html) testcase already contains a [test](https://github.com/dojo/dojo/blob/master/tests/request/xhr.html#L285) that is executed only if has("native-formdata") is true. When executed on iOS6, this test is not run, showing the faulty detection test. With the proposed fix, the test is executed (successfully).
