### PR TITLE
escape dash in regexp.escapeString, fixes #17861

### DIFF
--- a/regexp.js
+++ b/regexp.js
@@ -15,7 +15,7 @@ regexp.escapeString = function(/*String*/str, /*String?*/except){
 	// except:
 	//		a String with special characters to be left unescaped
 
-	return str.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, function(ch){
+	return str.replace(/([\.$?*|{}\(\)\[\]\\\/\+\-^])/g, function(ch){
 		if(except && except.indexOf(ch) != -1){
 			return ch;
 		}

--- a/tests/regexp.js
+++ b/tests/regexp.js
@@ -4,6 +4,7 @@ doh.register("tests.regexp",
 		function test_regexp_escape(t){
 			t.assertTrue(new RegExp(regexp.escapeString("\f\b\n\t\r+.$?*|{}()[]\\/^")).test("TEST\f\b\n\t\r+.$?*|{}()[]\\/^TEST"));
 			t.assertTrue(new RegExp(regexp.escapeString("\f\b\n\t\r+.$?*|{}()[]\\/^", ".")).test("TEST\f\b\n\t\r+X$?*|{}()[]\\/^TEST"));
+			t.is("a\\-z", regexp.escapeString("a-z"));
 		}
 );
 


### PR DESCRIPTION
Fixes https://bugs.dojotoolkit.org/ticket/17861.  If there are no objections I'll check this in.
