### PR TITLE
return handles

### DIFF
--- a/_base/unload.js
+++ b/_base/unload.js
@@ -42,7 +42,7 @@ var unload = {
 				//		addOnWindowUnload for more info.
 			}));
 		}
-		on(win, "unload", lang.hitch(obj, functionName));
+		return on(win, "unload", lang.hitch(obj, functionName));
 	},
 
 	addOnUnload: function(/*Object?|Function?*/ obj, /*String|Function?*/ functionName){
@@ -74,7 +74,7 @@ var unload = {
 		//	|		unload.addOnUnload(foo, function(){console.log("", this.data);});
 		//	|	});
 
-		on(win, "beforeunload", lang.hitch(obj, functionName));
+		return on(win, "beforeunload", lang.hitch(obj, functionName));
 	}
 };
 


### PR DESCRIPTION
See ticket 17870
https://bugs.dojotoolkit.org/ticket/17870#ticket

addOnWindowUnload and addOnUnload should return a handle so we can
disconnect the event if needed
