### PR TITLE
Refactor empty() to work better on non-IE browsers.

### DIFF
--- a/dom-construct.js
+++ b/dom-construct.js
@@ -302,7 +302,7 @@ define(["exports", "./_base/kernel", "./sniff", "./_base/window", "./dom", "./do
 	};
 
 	function _empty(/*DomNode*/ node){
-		if(node.canHaveChildren){
+		if("innerHTML" in node){
 			try{
 				// fast path
 				node.innerHTML = "";
@@ -312,9 +312,10 @@ define(["exports", "./_base/kernel", "./sniff", "./_base/window", "./dom", "./do
 				// Fall through (saves bytes)
 			}
 		}
-		// SVG/strict elements don't support innerHTML/canHaveChildren, and OBJECT/APPLET elements in quirks node have canHaveChildren=false
+
+		// SVG/strict elements don't support innerHTML
 		for(var c; c = node.lastChild;){ // intentional assignment
-			_destroy(c, node); // destroy is better than removeChild so TABLE subelements are removed in proper order
+			node.removeChild(c);
 		}
 	}
 


### PR DESCRIPTION
1. Check node.innerHTML rather than node.canHaveChildren(), since the latter
   only works on IE.
2. Limit empty(parent) to orphaning parent's children, rather than orphaning
   parent's grandchildren.

Fixes https://bugs.dojotoolkit.org/ticket/17869.

IIRC there was a lot of debate about whether a scorched-earth `destroy()` method did more harm than good on IE, and by corollary debate about how `empty()` should work.   But `empty()` is somewhat a different ball of wax from `destroy()`: while `destroy()` is arguably supposed to work recursively, `empty(parent)` arguably shouldn't orphan the parent's grandchildren.
