### PR TITLE
remove failing jsonp rpc test 

### DIFF
--- a/tests/rpc.js
+++ b/tests/rpc.js
@@ -101,40 +101,6 @@ define(["doh/main", "require", "../rpc/RpcService", "../rpc/JsonService", "../rp
 					return new Error("Error loading and/or parsing an smd file");
 				}
 			}
-		},
-
-		{
-			name: "JsonP_test",
-			timeout: 10000,
-			setUp: function(){
-				this.svc = new JsonpService(require.toUrl("dojo/tests/resources/yahoo_smd_v1.smd"), {appid: "foo"});
-			},
-			runTest: function(){
-				var d = new doh.Deferred();
-
-				if (window.location.protocol=="file:"){
-					var err= new Error("This Test requires a webserver and will fail intentionally if loaded from file://");
-					d.errback(err);
-					return d;
-				}
-
-				var td = this.svc.webSearch({query:"dojotoolkit"});
-
-				td.addCallbacks(function(result){
-					return true;
-					if (result["ResultSet"]["Result"][0]["DisplayUrl"]=="dojotoolkit.org/"){
-						return true;
-					}else{
-						return new Error("JsonRpc_SMD_Loading_Test failed, resultant content didn't match");
-					}
-				}, function(result){
-					return new Error(result);
-				});
-
-				td.addBoth(d, "callback");
-
-				return d;
-			}
 		}
 	]);
 


### PR DESCRIPTION
refs #17968, Yahoo search API service is no longer available, and other tests sufficiently cover testing via stubs.
