### PR TITLE
Remove test of 'Transfer-Encoding' header in chunked onProgress handler.

### DIFF
--- a/request/xhr.js
+++ b/request/xhr.js
@@ -99,7 +99,7 @@ define([
 					response.loaded = evt.loaded;
 					response.total = evt.total;
 					dfd.progress(response);
-				} else if(response.xhr.getResponseHeader('Transfer-Encoding') === 'chunked' && response.xhr.readyState === 3){
+				} else if(response.xhr.readyState === 3){
 					response.loaded = evt.position;
 					dfd.progress(response);
 				}


### PR DESCRIPTION
fixes #17823, add Add support for onProgress event when using Chunked…

For cross-origin requests, the browser will not generally allow you to
query any except "simple response headers". Transfer-Encoding isn't
one of them.
