### PR TITLE
XHR FormData Safari fix

### DIFF
--- a/request/xhr.js
+++ b/request/xhr.js
@@ -24,7 +24,7 @@ define([
 
 	has.add('native-formdata', function(){
 		// if true, the environment has a native FormData implementation
-		return typeof FormData === 'function';
+		return typeof FormData !== 'undefined';
 	});
 
 	function handleResponse(response, error){


### PR DESCRIPTION
XHR requests submitted with the `options.data` property set to an instance of a `FormData` object fails in Safari. Safari reports the type of `FormData` as `object` while other browsers return it as `function`. This leads to the fourth parameter passed to util.parseArgs at `dojo/request/xhr.js:133` as `false`. Thus, the FormData object had later been turned into a string at `dojo/request/util.js:125`.

This fix prevents the above scenario from happening by modifying the `has('native-formdata')` test.
