### PR TITLE
Report HTTP errors first, then handler errors, fixes #18088

### DIFF
--- a/request/xhr.js
+++ b/request/xhr.js
@@ -57,13 +57,14 @@ define([
 			}
 		}
 
-		if(error){
-			this.reject(error);
-		}else if(util.checkStatus(_xhr.status)){
-			this.resolve(response);
+		if(util.checkStatus(_xhr.status)){
+			if(error){
+				this.reject(error);
+			}else{
+				this.resolve(response);
+			}
 		}else{
 			error = new RequestError('Unable to load ' + response.url + ' status: ' + _xhr.status, response);
-
 			this.reject(error);
 		}
 	}


### PR DESCRIPTION
When reporting errors, it is better to report HTTP errors first.  Only report handler errors if the request was otherwise successful.  If you report the HTTP error first you can react to it by inspecting the status code.  This avoids xhr responding with a JSON parse error because you happened to get a 504 (session expired or somesuch), then a redirect to a login string.  Parsing a login screen as json will naturally fail.  And that error is somewhat useless as it doesn't tell you why it failed (due to HTTP request failure).

The pull provided is just a quick and simple reorder of how errors are reported.
