### PR TITLE
Fix issue with parentNode as null, fixes #18130

### DIFF
--- a/request/iframe.js
+++ b/request/iframe.js
@@ -179,7 +179,7 @@ define([
 					var parentNode = formNode;
 					do{
 						parentNode = parentNode.parentNode;
-					}while(parentNode !== win.doc.documentElement);
+					}while(parentNode && parentNode !== win.doc.documentElement);
 
 					// Append the form node or some browsers won't work
 					if(!parentNode){


### PR DESCRIPTION
This is a bug in the iframe handler for corner-cases of a form element being detached from the document when it is passed into the iframe handler.  The do/while loop should check that parentNode is not null in its search-back loop to avoid a parentNode is null error.  This is related to defect:

https://bugs.dojotoolkit.org/ticket/18130#ticket
