### PR TITLE
[cla] Fixed error in FF, iframes, and hccss, refs #16541

### DIFF
--- a/hccss.js
+++ b/hccss.js
@@ -29,7 +29,9 @@ define([
 		win.body().appendChild(div);
 
 		var cs = domStyle.getComputedStyle(div), bkImg, hc;
-		if(cs) bkImg = cs.backgroundImage;
+		if(cs){
+			bkImg = cs.backgroundImage;
+		}
 		hc = cs && (cs.borderTopColor == cs.borderRightColor) ||
 			(bkImg && (bkImg == "none" || bkImg == "url(invalid-url:)" ));
 


### PR DESCRIPTION
If Iframe(wich contains Dojo) is invisible, then FF don't computed style and cs is null: Error on domReady callback: TypeError: cs is null.
File for reproduce: https://yadi.sk/d/4kROZ4kwVjTqQ
