### PR TITLE
allow debounce to be bound

### DIFF
--- a/debounce.js
+++ b/debounce.js
@@ -24,7 +24,7 @@ define([], function(){
 			var a = arguments;
 			timer = setTimeout(function(){
 				cb.apply(this, a);
-			}, wait);
+			}.bind(this), wait);
 		};
 	};
 });


### PR DESCRIPTION
the existing debounce implementation attempts to bind the callback to this, but in the context of the setTimeout function, that is always Window.

this PR binds the setTimeout function to the context of the outer function, which allows the result of debounce to be bound to a context, just as throttle allows.
