### PR TITLE
Return/resolve actual newly created/updated item from dojo/store/DataStore (#18704)

### DIFF
--- a/store/DataStore.js
+++ b/store/DataStore.js
@@ -129,10 +129,10 @@ return declare("dojo.store.DataStore", base, {
 		var idProperty = this.idProperty;
 		var deferred = new Deferred();
 		if(typeof id == "undefined"){
-			store.newItem(object);
+			var item = store.newItem(object);
 			store.save({
 				onComplete: function(){
-					deferred.resolve(object);
+					deferred.resolve(item);
 				},
 				onError: function(error){
 					deferred.reject(error);
@@ -157,11 +157,11 @@ return declare("dojo.store.DataStore", base, {
 						if(options.overwrite === true){
 							return deferred.reject(new Error("Creating new object not allowed"));
 						}
-						store.newItem(object);
+						var item = store.newItem(object);
 					}
 					store.save({
 						onComplete: function(){
-							deferred.resolve(object);
+							deferred.resolve(item);
 						},
 						onError: function(error){
 							deferred.reject(error);


### PR DESCRIPTION
We are returning the actual newly created/updated item as returned from store. Best explained with an example: If we pass `{name: 'dojo'}` to `store.newItem()`, then we might get something like `{id: 99, name: 'dojo', 'date_created': ...}` returned from well-built REST server. Now that we have a deferred/promise here (since last commit), we would expect the resolved value to be the new value (as in `item`) returned from server (or whatever returned by the store), but not our original input (as in `object`). Without this fix, data consumers may get incomplete object which differs from actual store structure.