### PR TITLE
Refs #18168. dojo/on: adjust feature detection such that it also works in iOS 8 (beta) with a built dojo/on stripping the strict mode

### DIFF
--- a/on.js
+++ b/on.js
@@ -19,10 +19,15 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 				var EventDelegate = function(){};
 				EventDelegate.prototype =
 					document.createEvent("MouseEvents"); // original event
+				// Attempt to modify a property of an event delegate and check if
+				// it succeeds. Depending on browsers and on whether dojo/on's
+				// strict mode is stripped in a Dojo build, there are 3 known behaviors:
+				// it may either succeed, or raise an error, or fail to set the property
+				// without raising an error.
 				try{
-					// Attempt to modify a property of an event delegate:
-					(new EventDelegate).target = null;
-					return true; // can use event delegation
+					var eventDelegate = new EventDelegate;
+					eventDelegate.target = null;
+					return eventDelegate.target === null;
 				}catch(e){
 					return false; // cannot use event delegation
 				}


### PR DESCRIPTION
The previous feature detection code used by dojo/on for deciding whether to use event delegation is broken if and only if a built dojo/on stripping the strict mode is used on iOS 8 (beta). This is because, in non-strict mode, the assignment of event delegate's property fails without raising an error. (Note that the unbuilt dojo/on is in strict mode, thus is not affected by this issue, and there are means for a built dojo/on to preserve its strict mode).

The present PR fixes the misbehavior in non-strict mode on iOS 8 (beta), and has been tested successfully in strict and non-strict modes, with iOS 8 beta 5 and other OS versions as well. 
