### PR TITLE
prevent right clicks from firing click event through touch.js in IE10+ - fixing #18342

### DIFF
--- a/touch.js
+++ b/touch.js
@@ -123,6 +123,9 @@ function(dojo, aspect, dom, domClass, lang, on, has, mouse, domReady, win){
 				}
 
 				win.doc.addEventListener(moveType, function(e){
+					if(mouse.isRight(e)){
+						return;
+					}
 					updateClickTracker(e);
 					if(useTarget){
 						// prevent native scroll event and ensure touchend is
@@ -132,6 +135,9 @@ function(dojo, aspect, dom, domClass, lang, on, has, mouse, domReady, win){
 				}, true);
 
 				win.doc.addEventListener(endType, function(e){
+					if(mouse.isRight(e)){
+						return;
+					}
 					updateClickTracker(e);
 					if(clickTracker){
 						clickTime = (new Date()).getTime();


### PR DESCRIPTION
https://bugs.dojotoolkit.org/ticket/18342

As mentioned in the bug - an example of the erroneous behaviour can be seen [here](http://codepen.io/benbrunton/pen/aszCH).

This is a simple fix, to prevent right clicks from firing click events on widgets
