### PR TITLE
Add 'finally' method to Promises

### DIFF
--- a/promise/Promise.js
+++ b/promise/Promise.js
@@ -115,6 +115,26 @@ define([
 			return this.then(null, errback);
 		},
 
+		finally: function(callbackOrErrback) {
+			// summary:
+			//		Add a callback to be invoked when the promise is resolved
+			//		or rejected. Returns a promise which is resolved or rejected
+			//		based on the initial state of the promise.
+			// callbackOrErrback: Function?
+			//		A function that is used both as a callback and errback.
+			// returns: dojo/promise/Promise
+			//		Returns a new promise that is resolved or rejected based on
+			//		the initial promise.
+
+			return this.then(function(success) {
+				callbackOrErrback(success);
+				return success;
+			}, function(error) {
+				callbackOrErrback(error);
+				throw error;
+			});
+		},
+
 		trace: function(){
 			return this;
 		},

--- a/promise/Promise.js
+++ b/promise/Promise.js
@@ -115,7 +115,7 @@ define([
 			return this.then(null, errback);
 		},
 
-		finally: function(callbackOrErrback) {
+		'finally': function(callbackOrErrback) {
 			// summary:
 			//		Add a callback to be invoked when the promise is resolved
 			//		or rejected. Returns a promise which is resolved or rejected
@@ -127,10 +127,10 @@ define([
 			//		the initial promise.
 
 			return this.then(function(success) {
-				callbackOrErrback(success);
+				callbackOrErrback();
 				return success;
 			}, function(error) {
-				callbackOrErrback(error);
+				callbackOrErrback();
 				throw error;
 			});
 		},

--- a/tests/promise/Promise.js
+++ b/tests/promise/Promise.js
@@ -35,36 +35,36 @@ define([
 		"finally(…) is always called": function(t){
 			var obj = {};
 			var deferred1 = new Deferred();
-			var thenResult, finallyResult;
+			var thenResult, finallyResult = false;
 			deferred1.promise.then(function(result){ thenResult = result; });
-			deferred1.promise.finally(function(result){ finallyResult = result; });
+			deferred1.promise['finally'](function(result){ finallyResult = true; });
 			deferred1.resolve(obj);
-			t.t(finallyResult === obj);
-			t.t(finallyResult === thenResult);
+			t.t(finallyResult);
+			t.t(obj === thenResult);
 
 			var deferred2 = new Deferred();
-			var thenResult2, finallyResult2;
+			var thenResult2, finallyResult2 = false;
 			deferred2.promise.then(null, function(result){ thenResult2 = result; });
-			deferred2.promise.finally(function(result){ finallyResult2 = result; });
+			deferred2.promise['finally'](function(){ finallyResult2 = true; });
 			deferred2.reject(obj);
-			t.t(finallyResult2 === obj);
-			t.t(finallyResult2 === thenResult2);
+			t.t(finallyResult2);
+			t.t(obj === thenResult2);
 		},
 
 		"Promise from finally(…) is resolved or rejected with original resolved or rejected value": function(t){
 			var obj = {};
 			var deferred1 = new Deferred();
-			var finallyResult;
-			var finallyPromise1 = deferred1.promise.finally(function(result){ finallyResult = result; });
+			var finallyResult = false;
+			var finallyPromise1 = deferred1.promise['finally'](function(){ finallyResult = true; });
 			deferred1.resolve(obj);
-			t.t(finallyResult === obj);
+			t.t(finallyResult);
 			t.t(finallyPromise1.isResolved());
 
 			var deferred2 = new Deferred();
-			var finallyResult2;
-			var finallyPromise2 = deferred2.promise.finally(function(result){ finallyResult2 = result; });
+			var finallyResult2 = false;
+			var finallyPromise2 = deferred2.promise['finally'](function(){ finallyResult2 = true; });
 			deferred2.reject(obj);
-			t.t(finallyResult2 === obj);
+			t.t(finallyResult2);
 			t.t(finallyPromise2.isRejected());
 		},
 

--- a/tests/promise/Promise.js
+++ b/tests/promise/Promise.js
@@ -32,6 +32,42 @@ define([
 			t.t(otherwiseResult === thenResult);
 		},
 
+		"finally(…) is always called": function(t){
+			var obj = {};
+			var deferred1 = new Deferred();
+			var thenResult, finallyResult;
+			deferred1.promise.then(function(result){ thenResult = result; });
+			deferred1.promise.finally(function(result){ finallyResult = result; });
+			deferred1.resolve(obj);
+			t.t(finallyResult === obj);
+			t.t(finallyResult === thenResult);
+
+			var deferred2 = new Deferred();
+			var thenResult2, finallyResult2;
+			deferred2.promise.then(null, function(result){ thenResult2 = result; });
+			deferred2.promise.finally(function(result){ finallyResult2 = result; });
+			deferred2.reject(obj);
+			t.t(finallyResult2 === obj);
+			t.t(finallyResult2 === thenResult2);
+		},
+
+		"Promise from finally(…) is resolved or rejected with original resolved or rejected value": function(t){
+			var obj = {};
+			var deferred1 = new Deferred();
+			var finallyResult;
+			var finallyPromise1 = deferred1.promise.finally(function(result){ finallyResult = result; });
+			deferred1.resolve(obj);
+			t.t(finallyResult === obj);
+			t.t(finallyPromise1.isResolved());
+
+			var deferred2 = new Deferred();
+			var finallyResult2;
+			var finallyPromise2 = deferred2.promise.finally(function(result){ finallyResult2 = result; });
+			deferred2.reject(obj);
+			t.t(finallyResult2 === obj);
+			t.t(finallyPromise2.isRejected());
+		},
+
 		"trace() returns the same promise": function(t){
 			var promise = this.deferred.promise.trace();
 			t.t(promise === this.deferred.promise);
@@ -53,7 +89,7 @@ define([
 	}
 
 	function setUp(){
-		this.deferred = new Deferred;
+		this.deferred = new Deferred();
 	}
 
 	doh.register("tests.promise.Promise", wrapped);


### PR DESCRIPTION
It behaves essentially like `always(fn)`, but will resolve or reject the resultant promise based on the initial resolution or rejection.  Implements [18384](https://bugs.dojotoolkit.org/ticket/18384).
