### PR TITLE
Update window.js

### DIFF
--- a/window.js
+++ b/window.js
@@ -105,7 +105,12 @@ define(["./_base/lang", "./sniff", "./_base/window", "./dom", "./dom-geometry", 
 				In IE 6, only the variable "window" can be used to connect events (others
 				may be only copies).
 				*/
-				doc.parentWindow.execScript("document._parentWindow = window;", "Javascript");
+				// execScript will not supportted from IE11
+				if(has("ie") > = 11){
+					doc.parentWindow.eval("document._parentWindow = window;");	
+				}else{
+					doc.parentWindow.execScript("document._parentWindow = window;", "Javascript");
+				}
 				//to prevent memory leak, unset it after use
 				//another possibility is to add an onUnload handler which seems overkill to me (liucougar)
 				var win = doc._parentWindow;


### PR DESCRIPTION
From IE 11, window.execScript is not supported, should use eval.