### PR TITLE
added error handling for http errors codes in nodejs (#18475)

### DIFF
--- a/request/node.js
+++ b/request/node.js
@@ -92,6 +92,12 @@ define([
 					clearTimeout(timeout);
 				}
 				response.text = body.join('');
+				if (response.status >= 400){
+					def.reject({
+						message: 'http response code ' +  response.status,
+						response: response
+					});
+				};
 				try{
 					handlers(response);
 					def.resolve(response);


### PR DESCRIPTION
request/node now calls "reject" if the http status code is >=400. Also added corresponding test case.

--> https://bugs.dojotoolkit.org/ticket/18475