### PR TITLE
don't match leading/trailing spaces when there is no currency symbol

### DIFF
--- a/number.js
+++ b/number.js
@@ -86,9 +86,14 @@ number._applyPattern = function(/*Number*/ value, /*String*/ pattern, /*number._
 	}else if(pattern.indexOf('\u00a4') != -1){
 		group = options.customs.currencyGroup || group;//mixins instead?
 		decimal = options.customs.currencyDecimal || decimal;// Should these be mixins instead?
-		pattern = pattern.replace(/\u00a4{1,3}/, function(match){
-			var prop = ["symbol", "currency", "displayName"][match.length-1];
-			return options[prop] || options.currency || "";
+		pattern = pattern.replace(/([\s\xa0]*)(\u00a4{1,3})([\s\xa0]*)/, function(match, before, target, after){
+			var prop = ["symbol", "currency", "displayName"][target.length-1],
+				symbol = options[prop] || options.currency || "";
+			// if there is no symbol, also remove surrounding whitespaces
+			if(!symbol){
+				return "";
+			}
+			return before+symbol+after;
 		});
 	}else if(pattern.indexOf('E') != -1){
 		throw new Error("exponential notation not supported");
@@ -350,6 +355,12 @@ number._parseInfo = function(/*Object?*/ options){
 		re = re.replace(/([\s\xa0]*)(\u00a4{1,3})([\s\xa0]*)/g, function(match, before, target, after){
 			var prop = ["symbol", "currency", "displayName"][target.length-1],
 				symbol = dregexp.escapeString(options[prop] || options.currency || "");
+
+			// if there is no symbol there is no need to take white-spaces into account.
+			if(!symbol){
+				return "";
+			}
+
 			before = before ? "[\\s\\xa0]" : "";
 			after = after ? "[\\s\\xa0]" : "";
 			if(!options.strict){

--- a/tests/unit/number.js
+++ b/tests/unit/number.js
@@ -12,6 +12,12 @@ define([
 		assert.notStrictEqual(value, value);
 	}
 
+	function isStrictNaN(value) {
+		// reliable test for NaN (not subject to coercion)
+		// isNaN(undefined) return true in Chrome 40
+		return value !== value;
+	}
+
 	function decimalNumberDiff(num1, num2) {
 		//TODO: should be more accurate when dojo/number finish rounding in the future
 		var diffBound = 1e-3;
@@ -38,8 +44,10 @@ define([
 
 		var str = pattern == null ? 'default' : pattern;
 		var result = number.format(sourceInput, options);
-		if (expected == null) {
-		    assert.strictEqual(result, expected);
+		if (isStrictNaN(expected)) {
+			assertStrictNaN(result);
+		} else {
+			assert.strictEqual(result, expected);
 		}
 		if (backwardCheck) {
 			var resultParsed = number.parse(result,options);
@@ -61,8 +69,10 @@ define([
 		//print('input:' + sourceInput);
 		var result = number.parse(sourceInput, options);
 		//print('result :' + result);
-		if (expected != null){
-		    assert.strictEqual(result, expected);
+		if (isStrictNaN(expected)) {
+			assertStrictNaN(result);
+		} else {
+			assert.strictEqual(result, expected);
 		}
 	}
 
@@ -343,6 +353,36 @@ define([
 				assert.strictEqual(number.parse('123.4', {places:1, locale: 'en-us'}), 123.4);
 				assert.strictEqual(number.parse('123.45', {places:'1,3', locale: 'en-us'}), 123.45);
 				assert.strictEqual(number.parse('123.45', {places:'0,2', locale: 'en-us'}), 123.45);
+			},
+			't18466': function () {
+				var locale = "fr";
+				checkParse({ pattern: "#,###.00 ¤;(#,###.00) ¤", locale: locale }, "1,00 ", NaN);
+				checkParse({ pattern: "#,###.00 ¤;(#,###.00) ¤", locale: locale }, "1,00", 1);
+				checkParse({ pattern: "#,###.00¤;(#,###.00)¤", locale: locale }, "1,00 ", NaN);
+				checkParse({ pattern: "#,###.00¤;(#,###.00)¤", locale: locale }, "1,00", 1);
+				checkParse({ pattern: "#,###.00 ¤;(#,###.00) ¤", locale: locale }, "1 000,00 ", NaN);
+				checkParse({ pattern: "#,###.00 ¤;(#,###.00) ¤", locale: locale }, "1 000,00", 1000);
+				checkParse({ pattern: "#,###.00¤;(#,###.00)¤", locale: locale }, "1 000,00 ", NaN);
+				checkParse({ pattern: "#,###.00¤;(#,###.00)¤", locale: locale }, "1 000,00", 1000);
+				checkFormatParseCycle({ pattern: "#,###.00 ¤;(#,###.00) ¤", locale: locale }, "1200", "1\xa0200,00", true)
+				checkFormatParseCycle({ pattern: "#,###.00¤;(#,###.00)¤", locale: locale }, "1200", "1\xa0200,00", true)
+				checkFormatParseCycle({ pattern: "#,###.00 ¤;(#,###.00) ¤", locale: locale }, "1200 ", "1\xa0200,00", true)
+				checkFormatParseCycle({ pattern: "#,###.00¤;(#,###.00)¤", locale: locale }, "1200 ", "1\xa0200,00", true)
+
+				checkParse({ pattern: "¤ #,###.00;¤ (#,###.00)", locale: locale }, " 1,00", NaN);
+				checkParse({ pattern: "¤ #,###.00;¤ (#,###.00)", locale: locale }, "1,00", 1);
+				checkParse({ pattern: "¤#,###.00;¤(#,###.00)", locale: locale }, " 1,00", NaN);
+				checkParse({ pattern: "¤#,###.00;¤(#,###.00)", locale: locale }, "1,00", 1);
+				checkParse({ pattern: "¤ #,###.00;¤ (#,###.00)", locale: locale }, " 1 000,00", NaN);
+				checkParse({ pattern: "¤ #,###.00;¤ (#,###.00)", locale: locale }, "1 000,00", 1000);
+				checkParse({ pattern: "¤#,###.00;¤(#,###.00)", locale: locale }, " 1 000,00", NaN);
+				checkParse({ pattern: "¤#,###.00;¤(#,###.00)", locale: locale }, "1 000,00", 1000);
+				checkFormatParseCycle({ pattern: "¤ #,###.00;¤ (#,###.00)", locale: locale }, "1200", "1\xa0200,00", true)
+				checkFormatParseCycle({ pattern: "¤#,###.00;¤(#,###.00)", locale: locale }, "1200", "1\xa0200,00", true)
+				checkFormatParseCycle({ pattern: "¤ #,###.00;¤ (#,###.00)", locale: locale }, " 1200", "1\xa0200,00", true)
+				checkFormatParseCycle({ pattern: "¤#,###.00;¤(#,###.00)", locale: locale }, " 1200 ", "1\xa0200,00", true)
+
+
 			}
 		},
 
@@ -410,14 +450,14 @@ define([
 
 
 			// NumberRegression.Test4052223
-			checkParse({ pattern: '#,#00.00' }, 'abc3');
+			checkParse({ pattern: '#,#00.00' }, 'abc3', NaN);
 
 			//TODO: got NaN instead of 1.222, is it ok?
 			//checkParse({pattern:'#,##0.###',locale:'en-us'},'1.222,111',1.222);
 			//checkParse({pattern:'#,##0.###',locale:'en-us'},'1.222x111',1.222);
 
 			//got NaN for illegal input, ok
-			checkParse(null,'hello: ,.#$@^&**10x');
+			checkParse(null,'hello: ,.#$@^&**10x', NaN);
 
 
 			// NumberRegression.Test4125885


### PR DESCRIPTION
This is a proposal to solve https://bugs.dojotoolkit.org/ticket/18466.

I will add an intern test as soon as I can.