### PR TITLE
fixes:#16138 add error listener for request/script

### DIFF
--- a/request/script.js
+++ b/request/script.js
@@ -162,6 +162,11 @@ define([
 			}
 		}
 
+		on.once(node, 'error', function (error) {
+			dfd.reject(error);
+			script._remove(dfd.id, options.frameDoc, true);
+		});
+
 		watch(dfd);
 
 		return returnDeferred ? dfd : dfd.promise;

--- a/tests/unit/request/script.js
+++ b/tests/unit/request/script.js
@@ -46,6 +46,23 @@ define([
 			);
 		},
 
+		'script error event': function () {
+			var def = this.async();
+
+			script.get('/__services/non-existent-script', {
+				jsonp: 'callback',
+				timeout: 3000 // timeout for old IE
+			}).then(def.reject, def.callback(function (error) {
+				if (error.type) {
+					assert.strictEqual(error.type, 'error');
+				}
+				else {
+					// old IE doesn't emit an error event, timeout instead
+					assert.instanceOf(error, RequestTimeoutError);
+				}
+			}));
+		},
+
 		jsonp: function () {
 			var def = this.async();
 


### PR DESCRIPTION
Add an event listener on scripts using request/script which rejects the
promise, and a unit test. An error is not emitted on the script tag in
old IE, so timeout the test instead.

Fixes https://bugs.dojotoolkit.org/ticket/16138.