### PR TITLE
add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,10 @@
 	"bugs": "http://bugs.dojotoolkit.org/",
 	"keywords": ["JavaScript", "Dojo", "Toolkit"],
 	"homepage": "http://dojotoolkit.org/",
+	"repository":
+        { 
+                "type": "git",
+                "url": "https://github.com/dojo/dojo.git"
+        },
 	"dojoBuild": "dojo.profile.js"
 }


### PR DESCRIPTION
this may be a bit ocd but npm warns about this and I'd like to make it stop.