### PR TITLE
Fixed various issues with sniff on WP 8.1 U1, fixes #18540

### DIFF
--- a/sniff.js
+++ b/sniff.js
@@ -19,11 +19,14 @@ define(["./has"], function(has){
 		has.add("wp", parseFloat(dua.split("Windows Phone")[1]) || undefined);
 		has.add("msapp", parseFloat(dua.split("MSAppHost/")[1]) || undefined);
 		has.add("khtml", dav.indexOf("Konqueror") >= 0 ? tv : undefined);
-		has.add("webkit", parseFloat(dua.split("WebKit/")[1]) || undefined);
+		has.add("webkit", !has("wp") // NOTE: necessary since Windows Phone 8.1 Update 1, see #18540
+				&& parseFloat(dua.split("WebKit/")[1]) || undefined);
 		has.add("chrome", parseFloat(dua.split("Chrome/")[1]) || undefined);
 		has.add("android", !has("wp") // NOTE: necessary since Windows Phone 8.1 Update 1, see #18528
 				&& parseFloat(dua.split("Android ")[1]) || undefined);
-		has.add("safari", dav.indexOf("Safari") >= 0 && !has("chrome") && !has("android") ?
+		has.add("safari", dav.indexOf("Safari") >= 0 
+				&& !has("wp") // NOTE: necessary since Windows Phone 8.1 Update 1, see #18540
+				&& !has("chrome") && !has("android") ?
 			parseFloat(dav.split("Version/")[1]) : undefined);
 		has.add("mac", dav.indexOf("Macintosh") >= 0);
 		has.add("quirks", document.compatMode == "BackCompat");
@@ -49,7 +52,8 @@ define(["./has"], function(has){
 			}
 
 			// Mozilla and firefox
-			if(dua.indexOf("Gecko") >= 0 && !has("khtml") && !has("webkit") && !has("trident")){
+			if(dua.indexOf("Gecko") >= 0 && !has("wp") // NOTE: necessary since Windows Phone 8.1 Update 1
+					&& !has("khtml") && !has("webkit") && !has("trident")){
 				has.add("mozilla", tv);
 			}
 			if(has("mozilla")){


### PR DESCRIPTION
- fixed truthy has("webkit")
- previous fix enabled has("mozilla"), so I fixed that too
- fixed has("safari") returning NaN

Tested on WP 8.0, WP 8.1 and 8.1 U1

Here are the flags values after the fix on WP 8.1 U1

![after-fix](https://cloud.githubusercontent.com/assets/2982512/6826014/e68fda60-d2fe-11e4-8744-a858e677ccd3.PNG)
