### PR TITLE
[Built nls preloading] change back compatibility to match expected behavior. Fix #18556

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -374,7 +374,7 @@ define(["./_base/kernel", "require", "./has", "./_base/array", "./_base/config",
 											bundlePath = match[1] + "/";
 
 										// backcompat
-										bundle._localized = bundle._localized || {};
+										if (!bundle._localized){continue;}
 
 										var localized;
 										if(loc === "ROOT"){


### PR DESCRIPTION
The current backcompatibility code of the improved nls preloading introduced by 341e41f1797739449d883e8951cda54bde53417e does not have the expected behavior.

The `_localized` property added to the bundles contained in a layer during the build is used to find the best bundle without having to require the loose root bundle.

If this property does not exist it is currently set to an empty object (see [here](https://github.com/dojo/dojo/blob/master/i18n.js#L377)) which is wrong because this tells the i18n modules that there is no better locale than what it already has instead of just saying "there is no available information so the loose root bundle will be needed". 

For example, this is causing an issue if a user needs the locale `en-au` and the application is running "dojo after 341e41f1797739449d883e8951cda54bde53417e" and the application was built using "dojo before 341e41f1797739449d883e8951cda54bde53417e" and there is no layer for `en-au` but there is a loose bundle for `en-au`.
In that case, the bundle in the layer does not contain any information about this `en-au` loose bundle (those would be in the `_localized` property). But setting this property to the empty object tells the i18n loader that it should not bother loading the loose root bundle as it will not found any better locale which is not true in that case.

The expected behavior should be "skip the bundle improvement for now as we don't have information" (which is pre 1.9.3 behavior) which can be done using a `continue` statement.

This bug is present in 1.10, 1.9 and 1.8.
