### PR TITLE
Update html.js (#18703)

### DIFF
--- a/html.js
+++ b/html.js
@@ -40,6 +40,9 @@ define(["./_base/kernel", "./_base/lang", "./_base/array", "./_base/declare", ".
 			domConstruct.empty(node);
 
 			if(cont){
+				if(typeof cont == "number"){
+					cont = cont.toString();
+				}
 				if(typeof cont == "string"){
 					cont = domConstruct.toDom(cont, node.ownerDocument);
 				}
@@ -126,6 +129,9 @@ define(["./_base/kernel", "./_base/lang", "./_base/array", "./_base/declare", ".
 				//		If not provided, the object's content property will be used
 				if(undefined !== cont){
 					this.content = cont;
+				}
+				if(typeof cont == 'number'){
+					cont = cont.toString();
 				}
 				// in the re-use scenario, set needs to be able to mixin new configuration
 				if(params){

--- a/html.js
+++ b/html.js
@@ -350,6 +350,9 @@ define(["./_base/kernel", "./_base/lang", "./_base/array", "./_base/declare", ".
 				console.warn("dojo.html.set: no cont argument provided, using empty string");
 				cont = "";
 			}
+			if (typeof cont == 'number'){
+				cont = cont.toString();
+			}
 			if(!params){
 				// simple and fast
 				return html._setNodeContent(node, cont, true);

--- a/tests/unit/html.js
+++ b/tests/unit/html.js
@@ -73,6 +73,13 @@ define([
 					testHtmlSet(container, markup);
 				},
 
+				'numeric value': function () {
+					var markup = 1.618;
+
+					html.set(container, markup);
+					assert.strictEqual(container.innerHTML, markup.toString());
+				},
+
 				'attach onEnd handler': function () {
 					var msg = 'expected';
 					var handler = sinon.stub();


### PR DESCRIPTION
currently if a number is passed as the second argument to the dojo.html.set method it results in a "Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'" error and as i result i no longer have any hair left as i've ripped it all out. If javascript is automatically going to determine the variable type it stands to reason that numbers should be synonymous with strings in this instance