### PR TITLE
Reverse the order of locales merging during layer preload. Fix #18497

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -419,7 +419,10 @@ define(["./_base/kernel", "require", "./has", "./_base/array", "./_base/config",
 												if(requiredBundles.length){
 													preloadingAddLock();
 													contextRequire(requiredBundles, function(){
-														for(var i = 0; i < requiredBundles.length; i++){
+														// requiredBundles was constructed by forEachLocale so it contains locales from 
+														// less specific to most specific. 
+														// the loop starts with the most specific locale, the last one.
+														for(var i = requiredBundles.length - 1; i >= 0 ; i--){
 															bundle = lang.mixin(lang.clone(bundle), arguments[i]);
 															cache[cacheIds[i]] = bundle;
 														}


### PR DESCRIPTION
The locales are now merged in the right order, from less specific to most specific.

See: https://bugs.dojotoolkit.org/ticket/18497