### PR TITLE
Cache results of _getGregorianBundle(), fixes #18629.

### DIFF
--- a/date/locale.js
+++ b/date/locale.js
@@ -602,6 +602,7 @@ function _buildDateTimeRE(tokens, bundle, options, pattern){
 }
 
 var _customFormats = [];
+var _cachedGregorianBundles = {};
 exports.addCustomFormats = function(/*String*/ packageName, /*String*/ bundleName){
 	// summary:
 	//		Add a reference to a bundle containing localized custom formats to be
@@ -615,15 +616,19 @@ exports.addCustomFormats = function(/*String*/ packageName, /*String*/ bundleNam
 	//		The resources must be loaded by dojo.requireLocalization() prior to use
 
 	_customFormats.push({pkg:packageName,name:bundleName});
+	_cachedGregorianBundles = {};
 };
 
 exports._getGregorianBundle = function(/*String*/ locale){
+	if(_cachedGregorianBundles[locale]){
+		return _cachedGregorianBundles[locale];
+	}
 	var gregorian = {};
 	array.forEach(_customFormats, function(desc){
 		var bundle = i18n.getLocalization(desc.pkg, desc.name, locale);
 		gregorian = lang.mixin(gregorian, bundle);
 	}, this);
-	return gregorian; /*Object*/
+	return _cachedGregorianBundles[locale] = gregorian; /*Object*/
 };
 
 exports.addCustomFormats(module.id.replace(/\/date\/locale$/, ".cldr"),"gregorian");


### PR DESCRIPTION
Fixes performance of dojo/data/locale.format(), see https://bugs.dojotoolkit.org/ticket/18629.