### PR TITLE
event 'position' deprecation warning (#18702)

### DIFF
--- a/request/xhr.js
+++ b/request/xhr.js
@@ -115,7 +115,7 @@ define([
 					response.total = evt.total;
 					dfd.progress(response);
 				} else if(response.xhr.readyState === 3){
-					response.loaded = evt.position;
+					response.loaded = evt.loaded;
 					dfd.progress(response);
 				}
 			}

--- a/request/xhr.js
+++ b/request/xhr.js
@@ -115,7 +115,7 @@ define([
 					response.total = evt.total;
 					dfd.progress(response);
 				} else if(response.xhr.readyState === 3){
-					response.loaded = evt.loaded;
+					response.loaded = ('loaded' in evt) ? evt.loaded : evt.position;
 					dfd.progress(response);
 				}
 			}


### PR DESCRIPTION
Resolving event 'position' deprecation warning in chrome by using "loaded" property instead.

Resolves 18544 (https://bugs.dojotoolkit.org/ticket/18544)

Existing test cases should cover this trivial change.

My CLA username: gavinr