### PR TITLE
Exclude node_modules from minified build, copy only (#18648)

### DIFF
--- a/dojo.profile.js
+++ b/dojo.profile.js
@@ -1,5 +1,6 @@
 var profile = (function(){
 	var testResourceRe = /^dojo\/tests(?:DOH)?\//,
+		nodeModulesRe = /\/node_modules\//,
 
 		copyOnly = function(filename, mid){
 			var list = {
@@ -19,7 +20,7 @@ var profile = (function(){
 				/^dojo\/_base\/config\w+$/.test(mid) ||
 				(/^dojo\/resources\//.test(mid) && !/\.css$/.test(filename)) ||
 				/(png|jpg|jpeg|gif|tiff)$/.test(filename) ||
-				/\/node_modules\//.test(mid) ||
+				nodeModulesRe.test(mid) ||
 				/built\-i18n\-test\/152\-build/.test(mid);
 		};
 
@@ -38,7 +39,7 @@ var profile = (function(){
 			},
 
 			miniExclude: function(filename, mid){
-				return /\/node_modules\//.test(mid);
+				return nodeModulesRe.test(mid);
 			}
 		}
 	};

--- a/dojo.profile.js
+++ b/dojo.profile.js
@@ -19,13 +19,14 @@ var profile = (function(){
 				/^dojo\/_base\/config\w+$/.test(mid) ||
 				(/^dojo\/resources\//.test(mid) && !/\.css$/.test(filename)) ||
 				/(png|jpg|jpeg|gif|tiff)$/.test(filename) ||
+				/\/node_modules\//.test(mid) ||
 				/built\-i18n\-test\/152\-build/.test(mid);
 		};
 
 	return {
 		resourceTags:{
 			test: function(filename, mid){
-				return testResourceRe.test(mid) || mid=="dojo/tests" || mid=="dojo/robot" || mid=="dojo/robotx";
+				return testResourceRe.test(mid) || mid=="dojo/robot" || mid=="dojo/robotx";
 			},
 
 			copyOnly: function(filename, mid){
@@ -34,6 +35,10 @@ var profile = (function(){
 
 			amd: function(filename, mid){
 				return !testResourceRe.test(mid) && !copyOnly(filename, mid) && /\.js$/.test(filename);
+			},
+
+			miniExclude: function(filename, mid){
+				return /\/node_modules\//.test(mid);
 			}
 		}
 	};


### PR DESCRIPTION
Also remove redundant check for dojo/tests

Not sure if this is too heavy-handed, but I think it's a safer option than what we do today.