### PR TITLE
Add msedge to sauce config.

### DIFF
--- a/tests/dojo.intern.js
+++ b/tests/dojo.intern.js
@@ -38,8 +38,9 @@ define([
 				'prerun': 'http://localhost:9001/tests/support/prerun.bat' },
 			{ browserName: 'internet explorer', version: '10', platform: 'Windows 8',
 				'prerun': 'http://localhost:9001/tests/support/prerun.bat' },
-			{ browserName: 'internet explorer', version: '11', platform: 'Windows 8.1',
+			{ browserName: 'internet explorer', version: '11', platform: 'Windows 10',
 				'prerun': 'http://localhost:9001/tests/support/prerun.bat' },
+			{ browserName: 'microsoftedge', version: '20.10240', platform: 'Windows 10' },
 			{ browserName: 'firefox', version: '', platform: [ 'OS X 10.10', 'Windows 7' ] },
 			{ browserName: 'chrome', version: '', platform: [
 				'OS X 10.10', 'Windows 7'


### PR DESCRIPTION
This adds msedge to the sauce config.
I went with trying it without the prerun script first, will add if needed.

OT: I've pinged sauce about updating their version from `20.x` to `12.x` following the guidance
of [this post](http://blogs.windows.com/msedgedev/2015/09/21/understanding-versions-in-an-evergreen-browser/).