### PR TITLE
refs 18062, update IE feature detection of pointer event support

### DIFF
--- a/has.js
+++ b/has.js
@@ -111,7 +111,7 @@ define(["require", "module"], function(require, module){
 
 		// Pointer Events support
 		has.add("pointer-events", "onpointerdown" in document);
-		has.add("MSPointer", "msPointerEnabled" in navigator); //IE10 (+IE11 preview)
+		has.add("MSPointer", "MSPointerEvent" in window); //IE10 (+IE11 preview)
 
 		// I don't know if any of these tests are really correct, just a rough guess
 		has.add("device-width", screen.availWidth || innerWidth);

--- a/has.js
+++ b/has.js
@@ -111,7 +111,7 @@ define(["require", "module"], function(require, module){
 
 		// Pointer Events support
 		has.add("pointer-events", "onpointerdown" in document);
-		has.add("MSPointer", "msMaxTouchPoints" in navigator); //IE10 (+IE11 preview)
+		has.add("MSPointer", "msPointerEnabled" in navigator); //IE10 (+IE11 preview)
 
 		// I don't know if any of these tests are really correct, just a rough guess
 		has.add("device-width", screen.availWidth || innerWidth);


### PR DESCRIPTION
`window.MSPointerEvent` should be used instead of `navigator.msMaxTouchPoints` to determine pointer event support in IE10+.

Fixes [bug #18602](https://bugs.dojotoolkit.org/ticket/18602).