### PR TITLE
Correct reading of browser locale (#18722)

### DIFF
--- a/_base/config.js
+++ b/_base/config.js
@@ -185,8 +185,8 @@ return {
 	}
 
 	if(!result.locale && typeof navigator != "undefined"){
-		// Default locale for browsers.
-		var language = (navigator.language || navigator.userLanguage);
+		// Default locale for browsers (ensure it's read from user-settings not download locale).
+		var language = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage);
 		if(language){
 			result.locale = language.toLowerCase();
 		}


### PR DESCRIPTION
Correct the reading of the browser locale, to avoid situations where the language is taken from the locale from which the browser downloaded, rather than the user's chosen language settings. A common example is where Chrome returns en-US for users in the UK where the navigator.languages[0] would actually return en-GB instead.

See [this webpage on the subject](https://alicoding.com/detect-browser-language-preference-in-firefox-and-chrome-using-javascript/) for further background on making this change.

CLA signed under email address of dojofoundation`AT`martindoyle.com