### PR TITLE
Fix dojo.hash() when there's a <base> tag.

### DIFF
--- a/hash.js
+++ b/hash.js
@@ -38,7 +38,7 @@ define(["./_base/kernel", "require", "./_base/config", "./aspect", "./_base/lang
 		if(replace){
 			_replace(hash);
 		}else{
-			location.href = "#" + hash;
+			location.hash = "#" + hash;
 		}
 		return hash; // String
 	};
@@ -81,7 +81,8 @@ define(["./_base/kernel", "require", "./_base/config", "./aspect", "./_base/lang
 			_ieUriMonitor.iframe.location.replace(href.substring(0, index) + "?" + hash);
 			return;
 		}
-		location.replace("#"+hash);
+		var href = location.href.replace(/#.*/, "");
+		location.replace(href + "#" + hash);
 		!_connect && _pollLocation();
 	}
 

--- a/tests/functional/all.js
+++ b/tests/functional/all.js
@@ -8,6 +8,7 @@ define([
 	'./dnd',
 	'./fx',
 	'./fx/Toggler',
+	'./hash',
 	'./io/script',
 	'./on',
 	'./parser',

--- a/tests/functional/hash.js
+++ b/tests/functional/hash.js
@@ -1,0 +1,3 @@
+define([
+	'./hash/basehref'
+], function () { });

--- a/tests/functional/hash/basehref.html
+++ b/tests/functional/hash/basehref.html
@@ -1,0 +1,24 @@
+<html>
+<head>
+	<title>dojo.hash() with &lt;base&gt; test</title>
+	<script>
+		var ready = false;
+	</script>
+	<script type="text/javascript" src="../../../dojo.js" ></script>
+	<script>dojo.require('dojo.hash');</script>
+	<base href="http://dojotoolkit.org/">
+	<script>
+		dojo.ready(function(){
+			ready = true;
+		});
+	</script>
+</head>
+<body>
+	<h1>dojo.hash() with &lt;base&gt; test</h1>
+	<p id="_location"></p>
+	<div style="padding: 20px">
+		<button id='sethash' onclick="dojo.hash('#myhash1')">dojo.hash('#myhash1')</button>
+		<button id='sethashtrue' onclick="dojo.hash('#myhash2', true)">dojo.hash('#myhash2', true)</button>
+	</div>
+</body>
+</html>

--- a/tests/functional/hash/basehref.js
+++ b/tests/functional/hash/basehref.js
@@ -1,0 +1,23 @@
+define([
+	'require',
+	'intern!object',
+	'intern/chai!assert',
+	'../../support/ready'
+], function (require, registerSuite, assert, ready) {
+	registerSuite({
+		name: 'dojo/hash',
+
+		sethash: function () {
+			return ready(this.get('remote'), require.toUrl('./basehref.html'))
+				.findById('sethash').click().end()
+				.execute('return window.location.href').then(function(url){
+					assert.isTrue(/basehref\.html#myhash1$/.test(url), 'setHash("myhash1"), location.href: ' + url);
+				})
+				.findById('sethashtrue').click().end()
+				.execute('return window.location.href').then(function(url){
+					assert.isTrue(/basehref\.html#myhash2$/.test(url),
+						'setHash("myhash1", true), location.href: ' + url);
+				})
+		}
+	});
+});


### PR DESCRIPTION
Patch from Rob Retchless (IBM, CCLA) with some modifications by me.
Fixes #11100.

Tested on IE10, FF (version 31, since Intern doesn't work against the latest), Chrome, and manually on IE8.