### PR TITLE
Fix dojo/touch to not break native checkbox and radio on iOS and Android  when dojoClick=true

### DIFF
--- a/tests/functional/support/touch_dojoclick2.html
+++ b/tests/functional/support/touch_dojoclick2.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>test dojo/touch dojoClick property with input of type checkbox and radio</title>
+		<meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+		<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"/>
+		<meta name="apple-mobile-web-app-capable" content="yes"/>
+
+		<!-- Test for #18352 -->
+		<!-- Checks that dojo/touch with dojoClick=true does not break interaction with "native" HTML input -->
+		<!-- of type checkbox and radio (used to be broken on iOS and Android).	-->
+
+		<script src="../../../dojo.js" data-dojo-config="async: true, isDebug: true"></script>
+
+		<script>
+			document.dojoClick = true;
+			var ready = false;
+			// this, along with setting dojoClick, triggers the bug
+			require(["dojo/touch", "dojo/domReady!"], function(){
+				ready = true;
+			});
+			
+		</script>
+	</head>
+	<body>
+		<h1>Test dojo/touch's dojoClick property with input of type checkbox and radio</h1>
+
+		<input type="checkbox" id="dojoClickCheckbox"/><label for="dojoClickCheckbox">dojoClick=true</label>
+		<br/><br/>
+
+		<input type="radio" id="dojoClickRadio1" name="dojoClickRadio" value="1" checked>
+		<label for="dojoClickRadio1">One</label><br/>
+		<input type="radio" id="dojoClickRadio2" name="dojoClickRadio" value="2" checked>
+		<label for="dojoClickRadio2">Two</label><br/>
+	</body>
+</html>

--- a/tests/functional/support/touch_dojoclick2.html
+++ b/tests/functional/support/touch_dojoclick2.html
@@ -15,22 +15,28 @@
 		<script>
 			document.dojoClick = true;
 			var ready = false;
-			// this, along with setting dojoClick, triggers the bug
+			// loading dojo/touch, along with setting document.dojoClick at true, triggers the bug
 			require(["dojo/touch", "dojo/domReady!"], function(){
 				ready = true;
 			});
 			
 		</script>
 	</head>
-	<body>
+	<>
 		<h1>Test dojo/touch's dojoClick property with input of type checkbox and radio</h1>
 
-		<input type="checkbox" id="dojoClickCheckbox"/><label for="dojoClickCheckbox">dojoClick=true</label>
-		<br/><br/>
+		<p>
+			<input type="checkbox" id="dojoClickCheckbox">
+			<label for="dojoClickCheckbox">dojoClick=true</label>
+		</p>
 
-		<input type="radio" id="dojoClickRadio1" name="dojoClickRadio" value="1" checked>
-		<label for="dojoClickRadio1">One</label><br/>
-		<input type="radio" id="dojoClickRadio2" name="dojoClickRadio" value="2" checked>
-		<label for="dojoClickRadio2">Two</label><br/>
+		<p>
+			<input type="radio" id="dojoClickRadio1" name="dojoClickRadio" value="1" checked>
+			<label for="dojoClickRadio1">One</label>
+		</p>
+		<p>
+			<input type="radio" id="dojoClickRadio2" name="dojoClickRadio" value="2">
+			<label for="dojoClickRadio2">Two</label>
+		</p>
 	</body>
 </html>

--- a/tests/functional/support/touch_dojoclick2.html
+++ b/tests/functional/support/touch_dojoclick2.html
@@ -22,7 +22,7 @@
 			
 		</script>
 	</head>
-	<>
+	<body>
 		<h1>Test dojo/touch's dojoClick property with input of type checkbox and radio</h1>
 
 		<p>

--- a/tests/functional/touch.js
+++ b/tests/functional/touch.js
@@ -265,4 +265,46 @@ define([
 			}
 		};
 	});
+
+	// Tests for #18352
+	// Checks that dojo/touch with dojoClick=true does not break interaction with "native" HTML input
+	// of type checkbox and radio (used to be broken on iOS and Android).
+	registerSuite(function () {
+		var tapOrClick;
+
+		return {
+			name: 'dojo/touch dojoClick2 tests',
+
+			'before': function () {
+				// Not all browsers or drivers support touch events
+				tapOrClick = this.get('remote').environmentType.touchEnabled ?
+					tapElement :
+					clickElement;
+			},
+
+			'beforeEach': function () {
+				return ready(this.get('remote'), require.toUrl('./support/touch_dojoclick2.html'));
+			},
+
+			'press': function () {
+				return tapOrClick(this.get('remote').findById('dojoClickCheckbox'))
+					.execute(function () {
+						return dojoClickCheckbox.checked;
+					})
+					.then(function (result) {
+						assert.isTrue(result, 'dojoClicks2 - checkbox');
+					})
+					.end()
+					.findById('dojoClickRadio2')
+					.click()
+					.execute(function () {
+						return dojoClickRadio2.checked;
+					})
+					.then(function (result) {
+						assert.isTrue(result, 'dojoClicks2 - radio');
+					});
+			}
+		};
+	});
+
 });

--- a/touch.js
+++ b/touch.js
@@ -196,25 +196,26 @@ function(dojo, aspect, dom, domClass, lang, on, has, mouse, domReady, win){
 						// sent shortly after ours, similar to what is done in dualEvent.
 						// The INPUT.dijitOffScreen test is for offscreen inputs used in dijit/form/Button, on which
 						// we call click() explicitly, we don't want to stop this event.
+						var target = e.target;
 						if(clickTracker && !e._dojo_click &&
 								(new Date()).getTime() <= clickTime + 1000 &&
-								!(e.target.tagName == "INPUT" && domClass.contains(e.target, "dijitOffScreen"))){
+								!(target.tagName == "INPUT" && domClass.contains(target, "dijitOffScreen"))){
 							e.stopPropagation();
 							e.stopImmediatePropagation && e.stopImmediatePropagation();
 							if(type == "click" &&
-								(e.target.tagName != "INPUT" ||
-								(e.target.type == "radio" &&
+								(target.tagName != "INPUT" ||
+								(target.type == "radio" &&
 									// #18352 Do not preventDefault for radios that are not dijit or
 									// dojox/mobile widgets.
 									// (The CSS class dijitCheckBoxInput holds for both checkboxes and radio buttons.)
-									(domClass.contains(e.target, "dijitCheckBoxInput") ||
-										domClass.contains(e.target, "mblRadioButton"))) ||
-								(e.target.type == "checkbox" &&
+									(domClass.contains(target, "dijitCheckBoxInput") ||
+										domClass.contains(target, "mblRadioButton"))) ||
+								(target.type == "checkbox" &&
 									// #18352 Do not preventDefault for checkboxes that are not dijit or
 									// dojox/mobile widgets.
-									(domClass.contains(e.target, "dijitCheckBoxInput") ||
-										domClass.contains(e.target, "mblCheckBox")))) &&
-								e.target.tagName != "TEXTAREA" && e.target.tagName != "AUDIO" && e.target.tagName != "VIDEO"){
+									(domClass.contains(target, "dijitCheckBoxInput") ||
+										domClass.contains(target, "mblCheckBox")))) &&
+								target.tagName != "TEXTAREA" && target.tagName != "AUDIO" && target.tagName != "VIDEO"){
 								// preventDefault() breaks textual <input>s on android, keyboard doesn't popup,
 								// but it is still needed for checkboxes and radio buttons, otherwise in some cases
 								// the checked state becomes inconsistent with the widget's state

--- a/touch.js
+++ b/touch.js
@@ -201,11 +201,23 @@ function(dojo, aspect, dom, domClass, lang, on, has, mouse, domReady, win){
 								!(e.target.tagName == "INPUT" && domClass.contains(e.target, "dijitOffScreen"))){
 							e.stopPropagation();
 							e.stopImmediatePropagation && e.stopImmediatePropagation();
-							if(type == "click" && (e.target.tagName != "INPUT" || e.target.type == "radio" || e.target.type == "checkbox")
-								&& e.target.tagName != "TEXTAREA" && e.target.tagName != "AUDIO" && e.target.tagName != "VIDEO"){
-								 // preventDefault() breaks textual <input>s on android, keyboard doesn't popup,
-								 // but it is still needed for checkboxes and radio buttons, otherwise in some cases
-								 // the checked state becomes inconsistent with the widget's state
+							if(type == "click" &&
+								(e.target.tagName != "INPUT" ||
+								(e.target.type == "radio" &&
+									// #18352 Do not preventDefault for radios that are not dijit or
+									// dojox/mobile widgets.
+									// (The CSS class dijitCheckBoxInput holds for both checkboxes and radio buttons.)
+									(domClass.contains(e.target, "dijitCheckBoxInput") ||
+										domClass.contains(e.target, "mblRadioButton"))) ||
+								(e.target.type == "checkbox" &&
+									// #18352 Do not preventDefault for checkboxes that are not dijit or
+									// dojox/mobile widgets.
+									(domClass.contains(e.target, "dijitCheckBoxInput") ||
+										domClass.contains(e.target, "mblCheckBox")))) &&
+								e.target.tagName != "TEXTAREA" && e.target.tagName != "AUDIO" && e.target.tagName != "VIDEO"){
+								// preventDefault() breaks textual <input>s on android, keyboard doesn't popup,
+								// but it is still needed for checkboxes and radio buttons, otherwise in some cases
+								// the checked state becomes inconsistent with the widget's state
 								e.preventDefault();
 							}
 						}


### PR DESCRIPTION
This PR is a proposal for fixing the following issue: when `dojo/touch` is used with `document.dojoClick=true`, "native" HTML input elements of type checkbox and radio are broken with iOS 8+ and Android 4+. 
See https://bugs.dojotoolkit.org/ticket/18352

How to reproduce: 
* Run on iOS 8+ or Android 4+ the functional test of dojo/touch enriched with a test case in the present PR, or 
* Load `tests/functional/support/touch_dojoclick2.html` from the present PR in a supported browser on iOS 8+ or Android 4+.

The issue has been found to hurt at least on: Safari/iOS 8.x, Safari/iOS 9.x, Chrome/Android 4.4.2 | 5.x, and 6.0. It does not hurt on desktop browsers. The proposed fix has been tested OK on all these platforms.

Remarks:
* The pros and cons of this proposed fix have already been discussed in https://bugs.dojotoolkit.org/ticket/18352.
* Intended to be backported to 1.9 and 1.10.
* The functional tests in dojo core are currently not configured to run on iOS or Android platforms (see https://github.com/dojo/dojo/blob/26325a952f7f93c7dee3d153bbcca9ce943c6bcb/tests/dojo.intern.js#L37-L50). To see how it goes, I have extended in my workspace the intern configuration to iPhone / iOS 9 and tried the execution on saucelabs (`npm run test-remote`), but only got timeouts and various errors, even when keeping just the dojo/touch functional test running only on iPhone.
* So in the present conditions the added test case in the dojo/touch functional test does not allow to check the fix on iOS/Android; but it will be the case the day the dojo/core functional tests will run on these platforms. 
* The HTML test file (`tests/functional/support/touch_dojoclick2.html`) used by the added functional test does allow manual testing on iOS/Android; I also verified that it does not break the automatic testing on the desktop platforms.
