### PR TITLE
fixes #18122, JsonRest _getTarget in 1.10.0 breaks targets / trailing =

### DIFF
--- a/store/JsonRest.js
+++ b/store/JsonRest.js
@@ -61,7 +61,7 @@ return declare("dojo.store.JsonRest", base, {
 	// descendingPrefix: String
 	//		The prefix to apply to sort attribute names that are ascending
 	descendingPrefix: "-",
-	 
+
 	_getTarget: function(id){
 		// summary:
 		//		If the target has no trailing '/', then append it.
@@ -69,7 +69,7 @@ return declare("dojo.store.JsonRest", base, {
 		//		The identity of the requested target
 		var target = this.target;
 		if(typeof id != "undefined"){
-			if(target.charAt(target.length-1) == '/'){
+			if((target.charAt(target.length-1) == '/') || target.charAt(target.length-1) == '=')){
 				target += id;
 			}else{
 				target += '/' + id;
@@ -77,7 +77,7 @@ return declare("dojo.store.JsonRest", base, {
 		}
 		return target;
 	},
-					
+
 	get: function(id, options){
 		// summary:
 		//		Retrieves an object by its identity. This will trigger a GET request to the server using

--- a/store/JsonRest.js
+++ b/store/JsonRest.js
@@ -69,7 +69,7 @@ return declare("dojo.store.JsonRest", base, {
 		//		The identity of the requested target
 		var target = this.target;
 		if(typeof id != "undefined"){
-			if((target.charAt(target.length-1) == '/') || target.charAt(target.length-1) == '=')){
+			if( (target.charAt(target.length-1) == '/') || (target.charAt(target.length-1) == '=')){
 				target += id;
 			}else{
 				target += '/' + id;

--- a/tests/unit/store/JsonRest.js
+++ b/tests/unit/store/JsonRest.js
@@ -200,6 +200,10 @@ define([
 			},
 			'with slash': function () {
 				assert.equal(store.target + 'foo', store._getTarget('foo'));
+			},
+			'with equals': function () {
+				store.target = store.target.slice(0, -1) + '=';
+				assert.equal(store.target + '=foo', store._getTarget('foo'));
 			}
 		},
 

--- a/tests/unit/store/JsonRest.js
+++ b/tests/unit/store/JsonRest.js
@@ -203,7 +203,7 @@ define([
 			},
 			'with equals': function () {
 				store.target = store.target.slice(0, -1) + '=';
-				assert.equal(store.target + '=foo', store._getTarget('foo'));
+				assert.equal(store.target + 'foo', store._getTarget('foo'));
 			}
 		},
 


### PR DESCRIPTION
Our tests are currently being skipped for dojo/store/JsonRest, but I think this is the right behavior and test based on my initial review. Feedback appreciated (and we should get the tests enabled for dojo/store/JsonRest also)!