### PR TITLE
fixes #18122, JsonRest _getTarget regression breaks targets with trailing =

### DIFF
--- a/store/JsonRest.js
+++ b/store/JsonRest.js
@@ -61,7 +61,7 @@ return declare("dojo.store.JsonRest", base, {
 	// descendingPrefix: String
 	//		The prefix to apply to sort attribute names that are ascending
 	descendingPrefix: "-",
-	 
+
 	_getTarget: function(id){
 		// summary:
 		//		If the target has no trailing '/', then append it.
@@ -69,7 +69,7 @@ return declare("dojo.store.JsonRest", base, {
 		//		The identity of the requested target
 		var target = this.target;
 		if(typeof id != "undefined"){
-			if(target.charAt(target.length-1) == '/'){
+			if((target.charAt(target.length-1) == '/') || (target.charAt(target.length-1) == '=')){
 				target += id;
 			}else{
 				target += '/' + id;
@@ -77,7 +77,7 @@ return declare("dojo.store.JsonRest", base, {
 		}
 		return target;
 	},
-					
+
 	get: function(id, options){
 		// summary:
 		//		Retrieves an object by its identity. This will trigger a GET request to the server using

--- a/tests/store/JsonRest.js
+++ b/tests/store/JsonRest.js
@@ -41,6 +41,9 @@ define(["doh/main", "require", "dojo/_base/lang", "dojo/store/JsonRest"], functi
 				// and with the slash
 				store.target = store.target + '/';
 				t.is(store.target + "foo", store._getTarget("foo"));
+				// and with an equals sign
+				store.target = store.target.slice(0, -1);
+				t.is(store.target + "=foo", store._getTarget("foo"));
 			},
 			function testQueryIterative(t){
 				var d = new doh.Deferred();


### PR DESCRIPTION
Separate version for 1.10 with DOH tests instead of Intern