### PR TITLE
fixes #17498, add modern opera has test

### DIFF
--- a/sniff.js
+++ b/sniff.js
@@ -20,15 +20,17 @@ define(["./has"], function(has){
 		has.add("msapp", parseFloat(dua.split("MSAppHost/")[1]) || undefined);
 		has.add("khtml", dav.indexOf("Konqueror") >= 0 ? tv : undefined);
 		has.add("edge", parseFloat(dua.split("Edge/")[1]) || undefined);
+		has.add("opr", parseFloat(dua.split("OPR/")[1]) || undefined);
+		// NOTE: https://dev.opera.com/blog/opera-user-agent-strings-opera-15-and-beyond/
 		has.add("webkit", !has("wp") // NOTE: necessary since Windows Phone 8.1 Update 1, see #18540
 			&& !has("edge") && parseFloat(dua.split("WebKit/")[1]) || undefined);
-		has.add("chrome", !has("edge")
+		has.add("chrome", !has("edge") && !has("opr")
 				&& parseFloat(dua.split("Chrome/")[1]) || undefined);
 		has.add("android", !has("wp") // NOTE: necessary since Windows Phone 8.1 Update 1, see #18528
 				&& parseFloat(dua.split("Android ")[1]) || undefined);
-		has.add("safari", dav.indexOf("Safari") >= 0 
+		has.add("safari", dav.indexOf("Safari") >= 0
 				&& !has("wp") // NOTE: necessary since Windows Phone 8.1 Update 1, see #18540
-				&& !has("chrome") && !has("android") && !has("edge") ?
+				&& !has("chrome") && !has("android") && !has("edge") && !has("opr") ?
 			parseFloat(dav.split("Version/")[1]) : undefined);
 		has.add("mac", dav.indexOf("Macintosh") >= 0);
 		has.add("quirks", document.compatMode == "BackCompat");


### PR DESCRIPTION
Yes, I know we all hate this code and feel dirty about it, but as long as we have a dojo/sniff module in 1.x, we should keep it current.