### PR TITLE
fixes #18100, prevent dojo-console-guarantee in webworkers environment

### DIFF
--- a/_base/kernel.js
+++ b/_base/kernel.js
@@ -147,10 +147,14 @@ define(["../has", "./config", "require", "module"], function(has, config, requir
 		};
 	}
 
-	has.add("dojo-guarantee-console",
-		// ensure that console.log, console.warn, etc. are defined
-		1
-	);
+	if(!has("host-webworker")){
+		// console is immutable in FF30+, https://bugs.dojotoolkit.org/ticket/18100
+		has.add("dojo-guarantee-console",
+			// ensure that console.log, console.warn, etc. are defined
+			1
+		);
+	}
+
 	if(has("dojo-guarantee-console")){
 		typeof console != "undefined" || (console = {});
 		//	Be careful to leave 'log' always at the end

--- a/dojo.js
+++ b/dojo.js
@@ -176,7 +176,8 @@
 			"dojo-dom-ready-api": 0,
 			"dojo-sniff": 0,
 			"dojo-inject-api": 1,
-			"host-webworker": 1
+			"host-webworker": 1,
+			"dojo-guarantee-console": 0 // console is immutable in FF30+, see https://bugs.dojotoolkit.org/ticket/18100
 		});
 
 		defaultConfig.loaderPatch = {


### PR DESCRIPTION
This is overly aggressive/slightly redundant, but given the nature of the failure, it seemed better to prevent things from breaking.