### PR TITLE
fixes #17628, null query for store/JsonRest

### DIFF
--- a/store/JsonRest.js
+++ b/store/JsonRest.js
@@ -180,6 +180,7 @@ return declare("dojo.store.JsonRest", base, {
 		var headers = lang.mixin({ Accept: this.accepts }, this.headers, options.headers);
 
 		var hasQuestionMark = this.target.indexOf("?") > -1;
+		query = query || ""; // https://bugs.dojotoolkit.org/ticket/17628
 		if(query && typeof query == "object"){
 			query = xhr.objectToQuery(query);
 			query = query ? (hasQuestionMark ? "&" : "?") + query: "";

--- a/tests/unit/store/JsonRest.js
+++ b/tests/unit/store/JsonRest.js
@@ -139,6 +139,16 @@ define([
 				}), lang.hitch(dfd, 'reject'));
 			},
 
+			'null query': function () {
+				var dfd = this.async();
+
+				store.query().then(dfd.callback(function (results) {
+					var object = results[0];
+					assert.equal(object.name, 'node1');
+					assert.equal(object.someProperty, 'somePropertyA');
+				}), lang.hitch(dfd, 'reject'));
+			},
+
 			'result iteration': function () {
 				var dfd = this.async();
 


### PR DESCRIPTION
The JsonRest tests pass when I run them locally and against the proxy, though the suite is still commented out in master.