### PR TITLE
fixes #18769, fixes #16223, useful error message when non 2xx response with JSON

### DIFF
--- a/request/xhr.js
+++ b/request/xhr.js
@@ -74,12 +74,28 @@ define([
 
 		if(error){
 			this.reject(error);
-		}else if(util.checkStatus(_xhr.status)){
-			this.resolve(response);
 		}else{
-			error = new RequestError('Unable to load ' + response.url + ' status: ' + _xhr.status, response);
-
-			this.reject(error);
+			try{
+				handlers(response);
+			}catch(e){
+				var handleError = e;
+			}
+			if(util.checkStatus(_xhr.status)){
+				if(!handleError){
+					this.resolve(response);
+				}else{
+					this.reject(handleError);
+				}
+			}else{
+				if(!handleError){
+					error = new RequestError('Unable to load ' + response.url + ' status: ' + _xhr.status, response);
+					this.reject(error);
+				}else{
+					error = new RequestError('Unable to load ' + response.url + ' status: ' + _xhr.status +
+						' and an error in handleAs: transformation of response', response);
+    				this.reject(error);
+				}
+			}
 		}
 	}
 

--- a/request/xhr.js
+++ b/request/xhr.js
@@ -71,14 +71,14 @@ define([
 				error = e;
 			}
 		}
-
+		var handleError;
 		if(error){
 			this.reject(error);
 		}else{
 			try{
 				handlers(response);
 			}catch(e){
-				var handleError = e;
+				handleError = e;
 			}
 			if(util.checkStatus(_xhr.status)){
 				if(!handleError){


### PR DESCRIPTION
Note this does not change the behavior, only how the error is reported. The scenario being handled better here is when someone specifies handleAs: "json", and they get a non-2XX response. handleAs json assumes the error response will also be wrapped as JSON, which is not consistently the case. The workaround is to not use handleAs: json, and only parse the success callback.

So this ticket just changes the logic a bit to return a more meaningful error message when someone gets a non-2XX response that is not JSON formatted, per the suggestion in https://bugs.dojotoolkit.org/ticket/18769#comment:2

This change passes the existing tests so I will land it in master. If you find any issues with it, please let me know.