### PR TITLE
fixes #17281 on matches check

### DIFF
--- a/on.js
+++ b/on.js
@@ -9,7 +9,7 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 		has.add("event-focusin", function(global, doc, element){
 			return 'onfocusin' in element;
 		});
-		
+
 		if(has("touch")){
 			has.add("touch-can-modify-event-delegate", function(){
 				// This feature test checks whether deleting a property of an event delegate works
@@ -67,9 +67,9 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 		//		If you use on.emit on a DOM node, it will use native event dispatching when possible.
 
 		if(typeof target.on == "function" && typeof type != "function" && !target.nodeType){
-			// delegate to the target's on() method, so it can handle it's own listening if it wants (unless it 
+			// delegate to the target's on() method, so it can handle it's own listening if it wants (unless it
 			// is DOM node and we may be dealing with jQuery or Prototype's incompatible addition to the
-			// Element prototype 
+			// Element prototype
 			return target.on(type, listener);
 		}
 		// delegate to main listener code
@@ -97,7 +97,7 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 	};
 	on.once = function(target, type, listener, dontFix){
 		// summary:
-		//		This function acts the same as on(), but will only call the listener once. The 
+		//		This function acts the same as on(), but will only call the listener once. The
 		//		listener will be called for the first
 		//		event that takes place and then listener will automatically be removed.
 		var signal = on(target, type, function(){
@@ -109,6 +109,7 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 		return signal;
 	};
 	on.parse = function(target, type, listener, addListener, dontFix, matchesTarget){
+		var events;
 		if(type.call){
 			// event handler function
 			// on(node, touch.press, touchListener);
@@ -120,13 +121,13 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 			events = type;
 		}else if(type.indexOf(",") > -1){
 			// we allow comma delimited event names, so you can register for multiple events at once
-			var events = type.split(/\s*,\s*/);
-		} 
+			events = type.split(/\s*,\s*/);
+		}
 		if(events){
 			var handles = [];
 			var i = 0;
 			var eventName;
-			while(eventName = events[i++]){
+			while(eventName == events[i++]){
 				handles.push(on.parse(target, eventName, listener, addListener, dontFix, matchesTarget));
 			}
 			handles.remove = function(){
@@ -156,12 +157,12 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 				listener = fixTouchListener(listener);
 			}
 			if(!has("event-orientationchange") && (type == "orientationchange")){
-				//"orientationchange" not supported <= Android 2.1, 
+				//"orientationchange" not supported <= Android 2.1,
 				//but works through "resize" on window
-				type = "resize"; 
+				type = "resize";
 				target = window;
 				listener = fixTouchListener(listener);
-			} 
+			}
 		}
 		if(addStopImmediate){
 			// add stopImmediatePropagation if it doesn't exist
@@ -209,7 +210,7 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 		//		The matching node, if any. Else you get false
 
 		// see if we have a valid matchesTarget or default to dojo/query
-		matchesTarget = matchesTarget && matchesTarget.matches ? matchesTarget : dojo.query;
+		matchesTarget = matchesTarget && (typeof matchesTarget.matches == "function") ? matchesTarget : dojo.query;
 		children = children !== false;
 		// there is a selector, so make sure it matches
 		if(node.nodeType != 1){
@@ -222,7 +223,7 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 			}
 		}
 		return node;
-	}
+	};
 	on.selector = function(selector, eventType, children){
 		// summary:
 		//		Creates a new extension event with event delegation. This is based on
@@ -235,7 +236,7 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 		// eventType:
 		//		The event to listen for
 		// children:
-		//		Indicates if children elements of the selector should be allowed. This defaults to 
+		//		Indicates if children elements of the selector should be allowed. This defaults to
 		//		true
 		// example:
 		// |	require(["dojo/on", "dojo/mouse", "dojo/query!css2"], function(on, mouse){
@@ -277,14 +278,14 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 		// summary:
 		//		Fires an event on the target object.
 		// target:
-		//		The target object to fire the event on. This can be a DOM element or a plain 
+		//		The target object to fire the event on. This can be a DOM element or a plain
 		//		JS object. If the target is a DOM element, native event emitting mechanisms
 		//		are used when possible.
 		// type:
-		//		The event type name. You can emulate standard native events like "click" and 
+		//		The event type name. You can emulate standard native events like "click" and
 		//		"mouseover" or create custom events like "open" or "finish".
 		// event:
-		//		An object that provides the properties for the event. See https://developer.mozilla.org/en/DOM/event.initEvent 
+		//		An object that provides the properties for the event. See https://developer.mozilla.org/en/DOM/event.initEvent
 		//		for some of the properties. These properties are copied to the event object.
 		//		Of particular importance are the cancelable and bubbles properties. The
 		//		cancelable property indicates whether or not the event has a default action
@@ -292,7 +293,7 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 		//		the event object. The bubbles property indicates whether or not the
 		//		event will bubble up the DOM tree. If bubbles is true, the event will be called
 		//		on the target and then each parent successively until the top of the tree
-		//		is reached or stopPropagation() is called. Both bubbles and cancelable 
+		//		is reached or stopPropagation() is called. Both bubbles and cancelable
 		//		default to false.
 		// returns:
 		//		If the event is cancelable and the event is not cancelled,
@@ -358,17 +359,17 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 					return listener.apply(this, arguments);
 				}
 			};
-		}
-	} 
+		};
+	}
 	if(has("dom-addeventlistener")){
 		// emitter that works with native event handling
 		on.emit = function(target, type, event){
 			if(target.dispatchEvent && document.createEvent){
 				// use the native event emitting mechanism if it is available on the target object
-				// create a generic event				
-				// we could create branch into the different types of event constructors, but 
-				// that would be a lot of extra code, with little benefit that I can see, seems 
-				// best to use the generic constructor and copy properties over, making it 
+				// create a generic event
+				// we could create branch into the different types of event constructors, but
+				// that would be a lot of extra code, with little benefit that I can see, seems
+				// best to use the generic constructor and copy properties over, making it
 				// easy to have events look like the ones created with specific initializers
 				var ownerDocument = target.ownerDocument || document;
 				var nativeEvent = ownerDocument.createEvent("HTMLEvents");
@@ -467,8 +468,8 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 		};
 		var fixAttach = function(target, type, listener){
 			listener = fixListener(listener);
-			if(((target.ownerDocument ? target.ownerDocument.parentWindow : target.parentWindow || target.window || window) != top || 
-						has("jscript") < 5.8) && 
+			if(((target.ownerDocument ? target.ownerDocument.parentWindow : target.parentWindow || target.window || window) != top ||
+						has("jscript") < 5.8) &&
 					!has("config-_allow_leaks")){
 				// IE will leak memory on certain handlers in frames (IE8 and earlier) and in unattached DOM nodes for JScript 5.7 and below.
 				// Here we use global redirection to solve the memory leaks
@@ -522,13 +523,13 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 			this.modified = true; // mark it as modified  (for defaultPrevented flag) so the event will be cached in IE
 		};
 	}
-	if(has("touch")){ 
+	if(has("touch")){
 		var EventDelegate = function(){};
-		var windowOrientation = window.orientation; 
-		var fixTouchListener = function(listener){ 
-			return function(originalEvent){ 
-				//Event normalization(for ontouchxxx and resize): 
-				//1.incorrect e.pageX|pageY in iOS 
+		var windowOrientation = window.orientation;
+		var fixTouchListener = function(listener){
+			return function(originalEvent){
+				//Event normalization(for ontouchxxx and resize):
+				//1.incorrect e.pageX|pageY in iOS
 				//2.there are no "e.rotation", "e.scale" and "onorientationchange" in Android
 				//3.More TBD e.g. force | screenX | screenX | clientX | clientY | radiusX | radiusY
 
@@ -538,7 +539,7 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 					var type = originalEvent.type;
 					try{
 						delete originalEvent.type; // on some JS engines (android), deleting properties makes them mutable
-					}catch(e){} 
+					}catch(e){}
 					if(originalEvent.type){
 						// Deleting the property of the original event did not work (this is the case of
 						// browsers such as older Safari iOS), hence fallback:
@@ -568,16 +569,16 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 					}
 					originalEvent.corrected = event;
 					if(type == 'resize'){
-						if(windowOrientation == window.orientation){ 
+						if(windowOrientation == window.orientation){
 							return null;//double tap causes an unexpected 'resize' in Android
-						} 
+						}
 						windowOrientation = window.orientation;
-						event.type = "orientationchange"; 
+						event.type = "orientationchange";
 						return listener.call(this, event);
 					}
 					// We use the original event and augment, rather than doing an expensive mixin operation
 					if(!("rotation" in event)){ // test to see if it has rotation
-						event.rotation = 0; 
+						event.rotation = 0;
 						event.scale = 1;
 					}
 					//use event.changedTouches[0].pageX|pageY|screenX|screenY|clientX|clientY|target
@@ -587,9 +588,9 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 						event[i] = firstChangeTouch[i];
 					}
 				}
-				return listener.call(this, event); 
-			}; 
-		}; 
+				return listener.call(this, event);
+			};
+		};
 	}
 	return on;
 });

--- a/on.js
+++ b/on.js
@@ -127,7 +127,7 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 			var handles = [];
 			var i = 0;
 			var eventName;
-			while(eventName == events[i++]){
+			while(eventName = events[i++]){ // intentional assignment
 				handles.push(on.parse(target, eventName, listener, addListener, dontFix, matchesTarget));
 			}
 			handles.remove = function(){


### PR DESCRIPTION
Add more robust check of matchesTarget type to workaround known obscure error. Also some linting clean-up.

Existing tests pass the same before and after this change.