### PR TITLE
fixes #16257, cloning of sparse arrays

### DIFF
--- a/_base/lang.js
+++ b/_base/lang.js
@@ -502,7 +502,7 @@ define(["./kernel", "../has", "../sniff"], function(dojo, has){
 				r = [];
 				for(i = 0, l = src.length; i < l; ++i){
 					if(i in src){
-						r.push(lang.clone(src[i]));
+						r[i] = lang.clone(src[i]);
 					}
 				}
 				// we don't clone functions for performance reasons

--- a/tests/unit/_base/lang.js
+++ b/tests/unit/_base/lang.js
@@ -312,6 +312,8 @@ define([
 			};
 
 			assert.deepEqual(obj1, lang.clone(obj1));
+			obj1.baz.b[6] = "c"; // intentional sparse populatation
+			assert.deepEqual(obj1, lang.clone(obj1), "Sparse arrays should be equal");
 		},
 
 		'.delegate': function () {

--- a/tests/unit/_base/lang.js
+++ b/tests/unit/_base/lang.js
@@ -313,7 +313,7 @@ define([
 
 			assert.deepEqual(obj1, lang.clone(obj1));
 			obj1.baz.b[6] = "c"; // intentional sparse populatation
-			assert.deepEqual(obj1, lang.clone(obj1), "Sparse arrays should be equal");
+			assert.deepEqual(obj1.baz.b, lang.clone(obj1).baz.b, "Sparse arrays should be equal");
 		},
 
 		'.delegate': function () {


### PR DESCRIPTION
Leaving this one open for review, as I want to make sure we're not doing something dumb with this change (either from a performance or unintended consequences perspective).

Note that while all of the tests pass before and after this change, I also tried this test, which fails:

```
assert.deepEqual(obj1.baz.b, lang.clone(obj1).baz.b, "Sparse arrays should be equal");
```

Which perhaps it should. That said, this one also passes:

```
assert.deepEqual(obj1.baz.b[6], lang.clone(obj1).baz.b[6], "Sparse arrays should be equal");
```

So really I would just appreciate a quick sanity check from someone before I land this. Thanks!