### PR TITLE
fixes #18321, corrected check for nextElementSibling

### DIFF
--- a/selector/acme.js
+++ b/selector/acme.js
@@ -502,7 +502,8 @@ define([
 	// to the spec, https://bugzilla.mozilla.org/show_bug.cgi?id=932501
 	// and https://www.w3.org/Bugs/Public/show_bug.cgi?id=23691 ,
 	// where nextElementSibling was implemented on the DocumentType
-	var _noNES = "nextElementSibling" in getDoc().documentElement;
+	var _noNES = !(htmlElmement.nextElementSibling ||
+		"nextElementSibling" in htmlElement);
 	var _ns = !_noNES ? "nextElementSibling" : "nextSibling";
 	var _ps = !_noNES ? "previousElementSibling" : "previousSibling";
 	var _simpleNodeTest = (_noNES ? _isElement : yesman);


### PR DESCRIPTION
Fix inverted condition check, and make it more efficient per the suggestion in #18321.