### PR TITLE
Allow dojo/request to send ArrayBuffer, Blob, and File types

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"http-proxy": "0.10.3",
 		"glob": "3.2.7",
 		"jsgi-node": "0.3.1",
-		"formidable": "1.0.14",
+		"formidable": "1.0.17",
 		"sinon": "1.12.2",
 		"dojo": "1.12.0-pre"
 	},

--- a/request/util.js
+++ b/request/util.js
@@ -119,9 +119,9 @@ define([
 	exports.parseArgs = function parseArgs(url, options, skipData){
 		var data = options.data,
 			query = options.query;
-		
+
 		if(data && !skipData){
-			if(typeof data === 'object'){
+			if(typeof data === 'object' && !(data instanceof ArrayBuffer || data instanceof Blob )){
 				options.data = ioQuery.objectToQuery(data);
 			}
 		}

--- a/tests/unit/_base/NodeList.js
+++ b/tests/unit/_base/NodeList.js
@@ -246,7 +246,7 @@ define([
                 },
                 "coords": function () {
                     var tnl = new NodeList(dojo.byId(sq100Id));
-                    assert.isTrue(dojo.isArray(tnl));
+                    assert.isTrue(dojo.isArrayLike(tnl));
                     assert.equal(120, tnl.coords()[0].w, 120);
                     assert.equal(130, tnl.coords()[0].h, 130);
                     assert.equal(query("body *").coords().length, document.body.getElementsByTagName("*").length);
@@ -363,9 +363,7 @@ define([
 
                 "splice": function () {
                     var pnl = new NodeList(t, t, c);
-                    console.debug(pnl.splice(1));
 
-                    /*
                     assert.equal(pnl.splice(1).length, 2);
                     assert.equal(pnl.length, 1);
                     pnl = new NodeList(t, t, c);
@@ -373,7 +371,6 @@ define([
                     assert.equal(pnl.length, 2);
                     pnl = new NodeList(t, t, c);
                     assert.equal(pnl.splice(-2).length, 2);
-                    */
                 },
 
                 "spliceInsert": function () {
@@ -469,7 +466,7 @@ define([
                 // layout DOM functions
                 "position": function () {
                     var tnl = new NodeList(dojo.byId('sq100-NodeList'));
-                    assert.isTrue(dojo.isArray(tnl));
+                    assert.isTrue(dojo.isArrayLike(tnl));
                     assert.equal(tnl.position()[0].w, 100);
                     assert.equal(tnl.position()[0].h, 100);
                     assert.equal(query("body *").position().length, document.body.getElementsByTagName("*").length);

--- a/tests/unit/aspect.js
+++ b/tests/unit/aspect.js
@@ -82,14 +82,14 @@ define([
 					var aspectAfterCount = 0;
 					require({
 						packages: [
-							{ name: 'dojo1', location: './' },
-							{ name: 'dojo2', location: './' }
+							{ name: 'dojo1', location: '.' },
+							{ name: 'dojo2', location: '.' }
 						]
 					}, ['dojo1/aspect', 'dojo2/aspect'], this.async().callback(function(aspectOne, aspectTwo) {
 						//empty function to aspect on
 						var target = {};
 						target.onclick = function() {};
-						
+
 						aspectOne.after(target, 'onclick', function() {
 							aspectAfterCount++;
 						});
@@ -99,9 +99,9 @@ define([
 						aspectTwo.after(target, 'onclick', function() {
 							aspectAfterCount++;
 						});
-		
+
 						target.onclick();
-						
+
 						assert.equal(aspectAfterCount, 3);
 					}));
 				},

--- a/tests/unit/request/xhr.js
+++ b/tests/unit/request/xhr.js
@@ -15,7 +15,6 @@ define([
 
 	registerSuite({
 		name: 'dojo/request/xhr',
-
 		'.get': function () {
 			var promise = xhr.get('/__services/request/xhr', {
 				preventCache: true,
@@ -48,7 +47,7 @@ define([
 				})
 			);
 		},
-		
+
 		'.get json with truthy value': function () {
 			var def = this.async(),
 				promise = xhr.get(require.toUrl('./support/truthy.json'), {
@@ -117,7 +116,88 @@ define([
 				def.reject
 			);
 		},
+		'.post ArrayBuffer': function() {
+			if (!ArrayBuffer) {
+				this.skip('ArrayBuffer not available');
+			}
+			var def = this.async(),
+				str = 'foo',
+				arrbuff = new ArrayBuffer(str.length),
+				i8array = new Uint8Array(arrbuff);
 
+			for (var i = 0; i < str.length; i++) {
+				i8array[i] = str.charCodeAt(i);
+			}
+			var promise = xhr.post('/__services/request/xhr', {
+				data: arrbuff,
+				handleAs: 'json',
+				headers: {
+					'Content-Type':'text/plain'
+				}
+			});
+
+			promise.response.then(
+				def.callback(function (response) {
+					assert.strictEqual(response.data.method, 'POST');
+					var payload = response.data.payload;
+
+					assert.deepEqual(payload, {'foo':''});
+				}),
+				def.reject
+			);
+		},
+		'.post Blob': function() {
+			if (!Blob) {
+				this.skip('Blob not available');
+			}
+			var def = this.async(),
+				str = 'foo',
+				blob = new Blob([str], {type:'text/plain'});
+
+			var promise = xhr.post('/__services/request/xhr', {
+				data: blob,
+				handleAs: 'json',
+				headers: {
+					'Content-Type':'text/plain'
+				}
+			});
+
+			promise.response.then(
+				def.callback(function (response) {
+					assert.strictEqual(response.data.method, 'POST');
+					var payload = response.data.payload;
+
+					assert.deepEqual(payload, {'foo':''});
+				}),
+				def.reject
+			);
+		},
+		'.post File': function() {
+			if (!File) {
+				this.skip('File not available');
+			}
+			var def = this.async(),
+				str = 'foo',
+				file = new File([str], 'bar.txt', {type:'text/plain'});
+
+			var promise = xhr.post('/__services/request/xhr', {
+				data: file,
+				handleAs: 'json',
+				headers: {
+					'Content-Type':'text/plain'
+				}
+			});
+
+			promise.response.then(
+				def.callback(function (response) {
+					assert.strictEqual(response.data.method, 'POST');
+					var payload = response.data.payload;
+
+					assert.deepEqual(payload, {'foo':''});
+				}),
+				def.reject
+			);
+		},
 		'.post with query': function () {
 			var def = this.async(),
 				promise = xhr.post('/__services/request/xhr', {


### PR DESCRIPTION
- added additional guards for what "data" objects get transformed into form-style post bodies so that ArrayBuffer, Blob, and File are ignored and added associated tests
- fixed tests that weren't working properly in Chrome 50 (OS X) when using `npm run test-proxy`