### PR TITLE
console-as-object test moved into a function

### DIFF
--- a/_base/kernel.js
+++ b/_base/kernel.js
@@ -157,7 +157,10 @@ define(["../has", "./config", "require", "module"], function(has, config, requir
 
 	if(has("dojo-guarantee-console")){
 		// IE 9 bug: https://bugs.dojotoolkit.org/ticket/18197
-		has.add("console-as-object", Function.prototype.bind && console && typeof console.log === "object");
+		has.add("console-as-object", function () {
+			return Function.prototype.bind && console && typeof console.log === "object";
+		});
+
 		typeof console != "undefined" || (console = {});  // intentional assignment
 		//	Be careful to leave 'log' always at the end
 		var cn = [


### PR DESCRIPTION
Moved the console-as-object test into a function to avoid it being evaluated before the console polyfill is loaded.