### PR TITLE
Updated dojo version in package.json's devDependencies to latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"jsgi-node": "0.3.1",
 		"formidable": "1.0.17",
 		"sinon": "1.12.2",
-		"dojo": "1.12.0-pre"
+		"dojo": "1.11.1"
 	},
 	"main": "main",
 	"scripts": {


### PR DESCRIPTION
updated version of dojo required to latest release (1.11.1) to fix issue where npm install fails. Ref: https://bugs.dojotoolkit.org/ticket/18828