### PR TITLE
fixed missing method on DocumentFragment in IE(11)

### DIFF
--- a/dom-construct.js
+++ b/dom-construct.js
@@ -132,6 +132,11 @@ define(["exports", "./_base/kernel", "./sniff", "./_base/window", "./dom", "./do
 		while((fc = master.firstChild)){ // intentional assignment
 			df.appendChild(fc);
 		}
+		if(!df.getElementById && df.querySelector){
+			df.getElementById=function(id){
+				return this.querySelector('#'+id);
+			};
+		}
 		return df; // DocumentFragment
 	};
 


### PR DESCRIPTION
This is a test case:

``` html
<html>
<body>
    <h1>Test</h1>
    <script src="dojo/dojo.js"></script>
    <script type="text/javascript">
        require(['dojo/dom-construct'], function(domConstruct) {
            var frag = domConstruct.toDom('<div id="foo">Hello World</div><div></div>');
            alert(frag instanceof DocumentFragment); // true
            alert(frag.getElementById); // function in FF and Chrome,  undefined in IE
            var foo = dojo.byId('foo',frag); // error in IE
            alert(foo); // HtmlDivElement
        });
    </script>
</body>
</html>
```

Tested in IE11
