### PR TITLE
fixes #17424, required module using 'i18n.getLocalization' is executed before nls bundle preload is completed.

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -247,10 +247,10 @@ define(["./_base/kernel", "require", "./has", "./_base/array", "./_base/config",
 				bundleName = match[5] || match[4],
 				bundlePathAndName = bundlePath + bundleName,
 				localeSpecified = (match[5] && match[4]),
-				targetLocale =	localeSpecified || dojo.locale || "";
-				loadTarget = bundlePathAndName + "/" + targetLocale;
-				loadList = localeSpecified ? [targetLocale] : getLocalesToLoad(targetLocale);
-				remaining = loadList.length;
+				targetLocale =	localeSpecified || dojo.locale || "",
+				loadTarget = bundlePathAndName + "/" + targetLocale,
+				loadList = localeSpecified ? [targetLocale] : getLocalesToLoad(targetLocale),
+				remaining = loadList.length,
 				finish = function(){
 					if(!--remaining){
 						load(lang.delegate(cache[loadTarget]));

--- a/i18n.js
+++ b/i18n.js
@@ -242,6 +242,21 @@ define(["./_base/kernel", "require", "./has", "./_base/array", "./_base/config",
 			//		of these additional transactions can be done concurrently. Owing to this analysis, the entire preloading
 			//		algorithm can be discard during a build by setting the has feature dojo-preload-i18n-Api to false.
 
+			var match = nlsRe.exec(id),
+				bundlePath = match[1] + "/",
+				bundleName = match[5] || match[4],
+				bundlePathAndName = bundlePath + bundleName,
+				localeSpecified = (match[5] && match[4]),
+				targetLocale =	localeSpecified || dojo.locale || "";
+				loadTarget = bundlePathAndName + "/" + targetLocale;
+				loadList = localeSpecified ? [targetLocale] : getLocalesToLoad(targetLocale);
+				remaining = loadList.length;
+				finish = function(){
+					if(!--remaining){
+						load(lang.delegate(cache[loadTarget]));
+					}
+				};
+
 			if(has("dojo-preload-i18n-Api")){
 				var split = id.split("*"),
 					preloadDemand = split[1] == "preload";
@@ -255,25 +270,11 @@ define(["./_base/kernel", "require", "./has", "./_base/array", "./_base/config",
 					// don't stall the loader!
 					load(1);
 				}
-				if(preloadDemand || waitForPreloads(id, require, load)){
+				if(preloadDemand || (waitForPreloads(id, require, load) && !cache[loadTarget])){
 					return;
 				}
 			}
 
-			var match = nlsRe.exec(id),
-				bundlePath = match[1] + "/",
-				bundleName = match[5] || match[4],
-				bundlePathAndName = bundlePath + bundleName,
-				localeSpecified = (match[5] && match[4]),
-				targetLocale =	localeSpecified || dojo.locale || "",
-				loadTarget = bundlePathAndName + "/" + targetLocale,
-				loadList = localeSpecified ? [targetLocale] : getLocalesToLoad(targetLocale),
-				remaining = loadList.length,
-				finish = function(){
-					if(!--remaining){
-						load(lang.delegate(cache[loadTarget]));
-					}
-				};
 			array.forEach(loadList, function(locale){
 				var target = bundlePathAndName + "/" + locale;
 				if(has("dojo-preload-i18n-Api")){


### PR DESCRIPTION
There is a specific scenario that can cause the `nls` preload not to be respected by the loader and as such the loader continues to execute the required modules before the `nls` preload has completed.

The bugged scenario has been reproduced in https://github.com/agubler/layer-build within branches, `master` and `minimal-example`.

The bug occurs when a layer is dynamically required and has an `nls` bundle that is not built into the layer containing only `nls` files that already exist in an nls bundle that has already been loaded.

Unit Test Incoming.

