### PR TITLE
Fixes #18838, Dojo Drag and Drop does not work on specifically Windows 10 IE11

### DIFF
--- a/dnd/Manager.js
+++ b/dnd/Manager.js
@@ -22,8 +22,8 @@ var Manager = declare("dojo.dnd.Manager", [Evented], {
 	},
 
 	// avatar's offset from the mouse
-	OFFSET_X: has("touch") ? 0 : 16,
-	OFFSET_Y: has("touch") ? -64 : 16,
+	OFFSET_X: has("touch") ? 4 : 16,
+	OFFSET_Y: has("touch") ? 4 : 16,
 
 	// methods
 	overSource: function(source){


### PR DESCRIPTION
Update avatar's offset in touch mode to ensure that it doesn't shadow the target