### PR TITLE
Update autoscroll.js to allow scrolling in one direction

### DIFF
--- a/dnd/autoscroll.js
+++ b/dnd/autoscroll.js
@@ -83,7 +83,6 @@ exports.autoScrollNodes = function(e){
 	for(var n = e.target; n;){
 		if(n.nodeType == 1 && (n.tagName.toLowerCase() in exports._validNodes)){
 			var s = domStyle.getComputedStyle(n),
-				overflow = (s.overflow.toLowerCase() in exports._validOverflow),
 				overflowX = (s.overflowX.toLowerCase() in exports._validOverflow),
 				overflowY = (s.overflowY.toLowerCase() in exports._validOverflow);
 			if(overflow || overflowX || overflowY){
@@ -91,7 +90,7 @@ exports.autoScrollNodes = function(e){
 				t = domGeom.position(n, true);
 			}
 			// overflow-x
-			if(overflow || overflowX){
+			if(overflowX){
 				w = Math.min(exports.H_TRIGGER_AUTOSCROLL, b.w / 2);
 				rx = e.pageX - t.x;
 				if(has("webkit") || has("opera")){
@@ -112,7 +111,7 @@ exports.autoScrollNodes = function(e){
 				}
 			}
 			// overflow-y
-			if(overflow || overflowY){
+			if(overflowY){
 				//console.log(b.l, b.t, t.x, t.y, n.scrollLeft, n.scrollTop);
 				h = Math.min(exports.V_TRIGGER_AUTOSCROLL, b.h / 2);
 				ry = e.pageY - t.y;

--- a/dnd/autoscroll.js
+++ b/dnd/autoscroll.js
@@ -85,7 +85,7 @@ exports.autoScrollNodes = function(e){
 			var s = domStyle.getComputedStyle(n),
 				overflowX = (s.overflowX.toLowerCase() in exports._validOverflow),
 				overflowY = (s.overflowY.toLowerCase() in exports._validOverflow);
-			if(overflow || overflowX || overflowY){
+			if(overflowX || overflowY){
 				b = domGeom.getContentBox(n, s);
 				t = domGeom.position(n, true);
 			}


### PR DESCRIPTION
Checking for computed 'overflow' is both redundant and causes issue with a panel which only allows scrolling in one direction. 

This is typically done by setting the value of 'overflow-x' or 'overflow-y' to 'auto' or 'scroll.' The computed 'overflow' value will be 'auto' or 'scroll' in this situation.

Reference: https://drafts.csswg.org/css-overflow-3/#overflow-properties