### PR TITLE
Fixed faulty if statement for IE check in sniff.js

### DIFF
--- a/sniff.js
+++ b/sniff.js
@@ -66,7 +66,7 @@ define(["./has"], function(has){
 			}
 
 			// IE
-			if(document.all && !has("opera")){
+			if(document.all !== undefined && !has("opera")){
 				var isIE = parseFloat(dav.split("MSIE ")[1]) || undefined;
 
 				//In cases where the page has an HTTP header or META tag with


### PR DESCRIPTION
When running IE 11 (11.0.9600.18321) with html header "X-UA-Compatible"
as “IE=edge;”, dojo was not recognising IE to be installed.

(document.all && !has("opera")) returns a HTML-collection;
(!!document.all && !has("opera")) returns false, even though should
return true.

(document.all !== undefined && !has("opera")) returns true and
continues correctly into the if-statement.

Related to Ticket 17311 (https://bugs.dojotoolkit.org/ticket/17311), that seem not to have been fixed in latest Dojo 1.11.2.