### PR TITLE
Fix 'declare' to work with CSP 'unsafe-eval'

### DIFF
--- a/_base/declare.js
+++ b/_base/declare.js
@@ -3,12 +3,16 @@ define(["./kernel", "../has", "./lang"], function(dojo, has, lang){
 	//		dojo/_base/declare
 
 	var mix = lang.mixin, op = Object.prototype, opts = op.toString,
-		xtor, counter = 0, cname = "constructor";
+		xtor, counter = 0, cname = "constructor", createNewFunction;
 
 	if(!has("csp-restrictions")){
 		xtor = new Function;
 	}else{
 		xtor = function(){};
+		// 'new Function()' is preferable when available since it does not create a closure
+		createNewFunction = function() {
+			return new function() {};
+		};
 	}
 
 	function err(msg, cls){ throw new Error("declare" + (cls ? " " + cls : "") + ": " + msg); }
@@ -781,7 +785,12 @@ define(["./kernel", "../has", "./lang"], function(dojo, has, lang){
 				t = bases[i];
 				(t._meta ? mixOwn : mix)(proto, t.prototype);
 				// chain in new constructor
-				ctor = new Function;
+				if (has('csp-restrictions')) {
+					ctor = createNewFunction();
+				}
+				else {
+					ctor = new Function;
+				}
 				ctor.superclass = superclass;
 				ctor.prototype = proto;
 				superclass = proto.constructor = ctor;

--- a/_base/declare.js
+++ b/_base/declare.js
@@ -785,7 +785,7 @@ define(["./kernel", "../has", "./lang"], function(dojo, has, lang){
 				t = bases[i];
 				(t._meta ? mixOwn : mix)(proto, t.prototype);
 				// chain in new constructor
-				if (has('csp-restrictions')) {
+				if (has("csp-restrictions")) {
 					ctor = createNewFunction();
 				}
 				else {

--- a/_base/declare.js
+++ b/_base/declare.js
@@ -3,16 +3,13 @@ define(["./kernel", "../has", "./lang"], function(dojo, has, lang){
 	//		dojo/_base/declare
 
 	var mix = lang.mixin, op = Object.prototype, opts = op.toString,
-		xtor, counter = 0, cname = "constructor", createNewFunction;
+		xtor, counter = 0, cname = "constructor";
 
 	if(!has("csp-restrictions")){
+		// 'new Function()' is preferable when available since it does not create a closure
 		xtor = new Function;
 	}else{
 		xtor = function(){};
-		// 'new Function()' is preferable when available since it does not create a closure
-		createNewFunction = function() {
-			return new function() {};
-		};
 	}
 
 	function err(msg, cls){ throw new Error("declare" + (cls ? " " + cls : "") + ": " + msg); }
@@ -786,7 +783,7 @@ define(["./kernel", "../has", "./lang"], function(dojo, has, lang){
 				(t._meta ? mixOwn : mix)(proto, t.prototype);
 				// chain in new constructor
 				if (has("csp-restrictions")) {
-					ctor = createNewFunction();
+					ctor = function () {};
 				}
 				else {
 					ctor = new Function;


### PR DESCRIPTION
The [fix](https://github.com/dojo/dojo/commit/de4325f615f3276a01dbe8a93fbf8f6f95ce2176) for [#15950](https://bugs.dojotoolkit.org/ticket/15950) seems to have missed an instance of `new Function`. This commit adds a `has("csp-restrictions")` guard and alternate logic.
