### PR TITLE
ref #18379 - improve error messages for missing key in string.substitute

### DIFF
--- a/string.js
+++ b/string.js
@@ -148,7 +148,13 @@ string.substitute = function(	/*String*/		template,
 			if(format){
 				value = lang.getObject(format, false, thisObject).call(thisObject, value, key);
 			}
-			return transform(value, key).toString();
+			var result = transform(value, key);
+
+			if (typeof value === 'undefined') {
+				throw 'string.substitute could not find key "' + key + '" in template';
+			}
+
+			return result.toString();
 		}); // String
 };
 


### PR DESCRIPTION
added improved messaging when string.substitute fails to find a key in the provided map

This PR is meant to address the concerns raised in https://github.com/dojo/dojo/pull/132 to improve the error messages that are presented when string.substitute fails to find a key in the provided map. The one additional change that I made was to put the check after the call to the "transform" function, just in case it handles an undefined result.

As mentioned in the discussions in the ticket and the original PR, this PR doesn't exactly address the ticket's request for a more graceful failure. Rather, it takes the approach that seemed to be preferred which is to still throw an exception, but make it more readable.