### PR TITLE
set data to null if options.data is undefined

### DIFF
--- a/request/xhr.js
+++ b/request/xhr.js
@@ -215,7 +215,8 @@ define([
 			remover = addListeners(_xhr, dfd, response);
 		}
 
-		var data = options.data,
+		// IE11 treats data: undefined different than other browsers
+		var data = typeof(options.data) === 'undefined' ? null : options.data,
 			async = !options.sync,
 			method = options.method;
 


### PR DESCRIPTION
This fixes #18810, which resulted in inconsistent behavior in IE11 if `undefined` was sent as data in an xhr.