### PR TITLE
Fixes #18868 - Hardcoded './util/…' paths in dojo-util break when installed via npm

### DIFF
--- a/_base/configNode.js
+++ b/_base/configNode.js
@@ -7,6 +7,27 @@ exports.config = function(config){
 		var arg = (process.argv[i] + "").split("=");
 		if(arg[0] == "load"){
 			deps.push(arg[1]);
+		}else if(arg[0] == "mapPackage") {
+			var parts = arg[1].split(":"),
+				name = parts[0],
+				location=parts[1],
+				isPrexisting = false;
+
+			for (var j = 0; j < config.packages.length; j++) {
+				var pkg = config.packages[j];
+				if (pkg.name === name) {
+					pkg.location = location;
+					isPrexisting = true;
+					break;
+				}
+			}
+
+			if (!isPrexisting) {
+				config.packages.push({
+					name: name,
+					location: location
+				});
+			}
 		}else{
 			args.push(arg);
 		}

--- a/_base/configRhino.js
+++ b/_base/configRhino.js
@@ -23,6 +23,27 @@ function rhinoDojoConfig(config, baseUrl, rhinoArgs){
 		var arg = (rhinoArgs[i] + "").split("=");
 		if(arg[0] == "load"){
 			deps.push(arg[1]);
+		}else if(arg[0] == "mapPackage") {
+			var parts = arg[1].split(":"),
+				name = parts[0],
+				location=parts[1],
+				isPrexisting = false;
+
+			for (var j = 0; j < config.packages.length; j++) {
+				var pkg = config.packages[j];
+				if (pkg.name === name) {
+					pkg.location = location;
+					isPrexisting = true;
+					break;
+				}
+			}
+
+			if (!isPrexisting) {
+				config.packages.push({
+					name: name,
+					location: location
+				});
+			}
 		}
 	}
 


### PR DESCRIPTION
add ability to pass 'mapPackage' parameter on the command line to add or override a package definition when invoking dojo (e.g. running the build system.

There are three use cases that have been considered:

1. Executing Dojo builds
1. Executing DOH tests using the command line
1. Executing DOH tests with the browser runner

This PR is intended to address the first two use cases. Another PR will be issued for the third case.

This PR adds the ability to add another parameter when invoking Dojo via the command line, either with Node or Rhino. The parameter allows dynamic package configuration to be mixed into the base package definition. The parameter format is of the form "mapPackage=name:location" where name and location represent the same properties on package object. This method can be used to override and existing package location or provide a new one.