### PR TITLE
Resolve #18871, allowing Firefox to load Dojo in iframe with display:none

### DIFF
--- a/dom-style.js
+++ b/dom-style.js
@@ -1,4 +1,4 @@
-define(["./sniff", "./dom"], function(has, dom){
+define(["./sniff", "./dom", "./_base/window"], function(has, dom, win){
 	// module:
 	//		dojo/dom-style
 
@@ -45,8 +45,10 @@ define(["./sniff", "./dom"], function(has, dom){
 		};
 	}else{
 		getComputedStyle = function(node){
+			var dv = node.ownerDocument.defaultView,
+				w = dv.opener ? dv : win.global.window.parent;
 			return node.nodeType == 1 /* ELEMENT_NODE*/ ?
-				node.ownerDocument.defaultView.getComputedStyle(node, null) : {};
+				w.getComputedStyle(node, null) : {};
 		};
 	}
 	style.getComputedStyle = getComputedStyle;

--- a/tests/unit/dom-style.js
+++ b/tests/unit/dom-style.js
@@ -50,6 +50,24 @@ define([
                     for (var i in map) {
                         assert.equal(result[i], map[i]);
                     }
+                },
+                "does not throw on frame elements": function () {
+                    var node = document.createElement("div"),
+                        frame = document.createElement("iframe"),
+                        frameDoc;
+
+                    node.appendChild(frame);
+                    container.appendChild(node);
+
+                    domStyle.set(frame, "display", "none");
+
+                    frameDoc = frame.contentWindow.document
+
+                    frameDoc.open();
+                    frameDoc.write("<!doctype html><html><body><div>Test</div></body></html>");
+                    frameDoc.close();
+
+                    assert.isNotNull(domStyle.getComputedStyle(frameDoc.body));
                 }
             },
         "toPixelValue()": {


### PR DESCRIPTION
Firefox returns null from `defaultView.getComputedStyle` in an iframe
with a style of `display: none;`. There is more information in the
discussion in [this thread](https://bugzilla.mozilla.org/show_bug.cgi?id=548397).

NOTE: To ensure the added test ran in Firefox, I had to `npm install
leadfoot@1.7.0` and delete
`node_modules/intern-geezer/node_modules/leadfoot`. This is due to a
need to update the `intern-geezer` library's dependance on an older
version of leadfoot that breaks Firefox 49+ compatibility.