### PR TITLE
Remove testQueryIterative. Fixes #18808

### DIFF
--- a/tests/store/JsonRest.js
+++ b/tests/store/JsonRest.js
@@ -45,18 +45,6 @@ define(["doh/main", "require", "dojo/_base/lang", "dojo/store/JsonRest"], functi
 				store.target = store.target.slice(0, -1);
 				t.is(store.target + "=foo", store._getTarget("foo"));
 			},
-			function testQueryIterative(t){
-				var d = new doh.Deferred();
-				var i = 0;
-				store.query("treeTestRoot").forEach(function(object){
-					i++;
-					console.log(i);
-					t.is(object.name, "node" + i);
-				}).then(function(){
-					d.callback(true);
-				});
-				return d;
-			},
 			function testHeaders(t){
 				var d = new doh.Deferred(),
 					error,

--- a/tests/store/JsonRest.js
+++ b/tests/store/JsonRest.js
@@ -42,8 +42,8 @@ define(["doh/main", "require", "dojo/_base/lang", "dojo/store/JsonRest"], functi
 				store.target = store.target + '/';
 				t.is(store.target + "foo", store._getTarget("foo"));
 				// and with an equals sign
-				store.target = store.target.slice(0, -1);
-				t.is(store.target + "=foo", store._getTarget("foo"));
+				store.target = store.target.slice(0, -1) + '=';
+				t.is(store.target + "foo", store._getTarget("foo"));
 			},
 			function testHeaders(t){
 				var d = new doh.Deferred(),


### PR DESCRIPTION
This PR removes the `testQueryIterative` test from the `JsonRest` suite, as well as updates the `_getTarget` test to be current with the latest Intern test from the 1.12 branch.

Please note, the `testHeaders` test is still failing but this is not a straightforward backport from Intern to DOH as the Intern tests require stubs and a different organization for that particular test. This is something we should look into if time permits.