### PR TITLE
strip fragment from URL before sending request for IE<=10, which brea…

### DIFF
--- a/request/xhr.js
+++ b/request/xhr.js
@@ -186,6 +186,11 @@ define([
 		url = response.url;
 		options = response.options;
 
+		if(has('ie') <= 10){
+			// older IE breaks point 9 in http://www.w3.org/TR/XMLHttpRequest/#the-open()-method and sends fragment, so strip it
+			url = url.split('#')[0];
+		}
+		
 		var remover,
 			last = function(){
 				remover && remover();

--- a/tests/services/request/xhr.service.js
+++ b/tests/services/request/xhr.service.js
@@ -44,6 +44,7 @@ define([
 							method: request.method,
 							query: request.query,
 							headers: request.headers,
+							url : request.nodeRequest.url,
 							payload: data || null
 						})
 					]

--- a/tests/unit/request/xhr.js
+++ b/tests/unit/request/xhr.js
@@ -408,6 +408,18 @@ define([
 			);
 		},
 
+		'strip fragment': function () {
+			var def = this.async(),
+				promise = xhr.get('/__services/request/xhr?color=blue#some-hash', {
+					handleAs: 'json'
+				});
+		
+			promise.response.then(def.callback(function (response) {
+				assert.strictEqual(response.data.method, 'GET');
+				assert.strictEqual(response.data.url, '/__services/request/xhr?color=blue');
+			}));
+		},
+
 		'form data': {
 			setup: function () {
 				if(!hasFormData) { return; }


### PR DESCRIPTION
IE9 & 10  do not strip fragment when it is provided in URL and send it to server. 
(maybe also lower versions, I have tested those versions; IE11 is OK).

This used to be spec violation (#9 in https://www.w3.org/TR/2012/WD-XMLHttpRequest-20121206/#dom-xmlhttprequest-open), but for some reason it does not appear in spec any more (https://xhr.spec.whatwg.org/#the-open()-method). But anyway, I consider this behavior as incorrect. 

I have reported this to MS as well (https://connect.microsoft.com/IE/feedback/details/785674/xmlhttprequest-sends-fragment-to-server), but without any success even after providing the test case.