### PR TITLE
dnd/Moveable: add support for pointer events with touch

### DIFF
--- a/dnd/Moveable.js
+++ b/dnd/Moveable.js
@@ -9,18 +9,17 @@ define([
 // The 'pointermove' event is only continuously emitted in a touch environment if
 // the target node's 'touch-action' CSS property is set to 'none'
 // https://www.w3.org/TR/pointerevents/#the-touch-action-css-property
-var needsTouchAction = has('touch') && has('pointer-events');
+var needsTouchAction = has("touch") && has("pointer-events");
 var touchActionPropertyName;
 var setTouchAction;
 
 if (needsTouchAction) {
-	if ('touchAction' in document.body.style) {
-		touchActionPropertyName = 'touchAction';
+	if ("touchAction" in document.body.style) {
+		touchActionPropertyName = "touchAction";
 	}
-	else if ('msTouchAction' in document.body.style) {
-		touchActionPropertyName = 'msTouchAction';
+	else if ("msTouchAction" in document.body.style) {
+		touchActionPropertyName = "msTouchAction";
 	}
-
 	setTouchAction = function setTouchAction(/* Node */ node, /* string */ action) {
 		node.style[touchActionPropertyName] = action;
 	}
@@ -41,11 +40,9 @@ var Moveable = declare("dojo.dnd.Moveable", [Evented], {
 		// params: Moveable.__MoveableArgs?
 		//		optional parameters
 		this.node = dom.byId(node);
-
 		if (needsTouchAction) {
-			setTouchAction(this.node, 'none');
+			setTouchAction(this.node, "none");
 		}
-
 		if(!params){ params = {}; }
 		this.handle = params.handle ? dom.byId(params.handle) : null;
 		if(!this.handle){ this.handle = this.node; }
@@ -70,11 +67,9 @@ var Moveable = declare("dojo.dnd.Moveable", [Evented], {
 		// summary:
 		//		stops watching for possible move, deletes all references, so the object can be garbage-collected
 		array.forEach(this.events, function(handle){ handle.remove(); });
-
 		if (needsTouchAction) {
-			setTouchAction(this.node, '');
+			setTouchAction(this.node, "");
 		}
-
 		this.events = this.node = this.handle = null;
 	},
 

--- a/dnd/Moveable.js
+++ b/dnd/Moveable.js
@@ -7,9 +7,9 @@ define([
 //		dojo/dnd/Moveable
 
 var touchActionPropertyName;
-var setTouchAction;
+var setTouchAction = function () {};
 
-if (has("touch-action")) {
+function setTouchActionPropertyName() {
 	if ("touchAction" in document.body.style) {
 		touchActionPropertyName = "touchAction";
 	}
@@ -19,6 +19,12 @@ if (has("touch-action")) {
 	setTouchAction = function setTouchAction(/* Node */ node, /* string */ action) {
 		node.style[touchActionPropertyName] = action;
 	}
+	setTouchAction(arguments[0], arguments[1]);
+}
+
+if (has("touch-action")) {
+	// Ensure that the logic to determine "touchActionPropertyName" runs
+	setTouchAction = setTouchActionPropertyName;
 }
 
 var Moveable = declare("dojo.dnd.Moveable", [Evented], {
@@ -36,9 +42,7 @@ var Moveable = declare("dojo.dnd.Moveable", [Evented], {
 		// params: Moveable.__MoveableArgs?
 		//		optional parameters
 		this.node = dom.byId(node);
-		if (has("touch-action")) {
-			setTouchAction(this.node, "none");
-		}
+		setTouchAction(this.node, "none");
 		if(!params){ params = {}; }
 		this.handle = params.handle ? dom.byId(params.handle) : null;
 		if(!this.handle){ this.handle = this.node; }
@@ -63,9 +67,7 @@ var Moveable = declare("dojo.dnd.Moveable", [Evented], {
 		// summary:
 		//		stops watching for possible move, deletes all references, so the object can be garbage-collected
 		array.forEach(this.events, function(handle){ handle.remove(); });
-		if (has("touch-action")) {
-			setTouchAction(this.node, "");
-		}
+		setTouchAction(this.node, "");
 		this.events = this.node = this.handle = null;
 	},
 

--- a/dnd/Moveable.js
+++ b/dnd/Moveable.js
@@ -6,14 +6,10 @@ define([
 // module:
 //		dojo/dnd/Moveable
 
-// The 'pointermove' event is only continuously emitted in a touch environment if
-// the target node's 'touch-action' CSS property is set to 'none'
-// https://www.w3.org/TR/pointerevents/#the-touch-action-css-property
-var needsTouchAction = has("touch") && has("pointer-events");
 var touchActionPropertyName;
 var setTouchAction;
 
-if (needsTouchAction) {
+if (has("touch-action")) {
 	if ("touchAction" in document.body.style) {
 		touchActionPropertyName = "touchAction";
 	}
@@ -40,7 +36,7 @@ var Moveable = declare("dojo.dnd.Moveable", [Evented], {
 		// params: Moveable.__MoveableArgs?
 		//		optional parameters
 		this.node = dom.byId(node);
-		if (needsTouchAction) {
+		if (has("touch-action")) {
 			setTouchAction(this.node, "none");
 		}
 		if(!params){ params = {}; }
@@ -67,7 +63,7 @@ var Moveable = declare("dojo.dnd.Moveable", [Evented], {
 		// summary:
 		//		stops watching for possible move, deletes all references, so the object can be garbage-collected
 		array.forEach(this.events, function(handle){ handle.remove(); });
-		if (needsTouchAction) {
+		if (has("touch-action")) {
 			setTouchAction(this.node, "");
 		}
 		this.events = this.node = this.handle = null;

--- a/dnd/Moveable.js
+++ b/dnd/Moveable.js
@@ -1,11 +1,30 @@
 define([
-	"../_base/array", "../_base/declare", "../_base/lang",
-	"../dom", "../dom-class", "../Evented", "../on", "../topic", "../touch", "./common", "./Mover", "../_base/window"
-], function(array, declare, lang, dom, domClass, Evented, on, topic, touch, dnd, Mover, win){
+	"../_base/array", "../_base/declare", "../_base/lang", "../dom", "../dom-class", "../Evented",
+	"../has", "../on", "../topic", "../touch", "./common", "./Mover", "../_base/window"
+], function(array, declare, lang, dom, domClass, Evented, has, on, topic, touch, dnd, Mover, win){
 
 // module:
 //		dojo/dnd/Moveable
 
+// The 'pointermove' event is only continuously emitted in a touch environment if
+// the target node's 'touch-action' CSS property is set to 'none'
+// https://www.w3.org/TR/pointerevents/#the-touch-action-css-property
+var needsTouchAction = has('touch') && has('pointer-events');
+var touchActionPropertyName;
+var setTouchAction;
+
+if (needsTouchAction) {
+	if ('touchAction' in document.body.style) {
+		touchActionPropertyName = 'touchAction';
+	}
+	else if ('msTouchAction' in document.body.style) {
+		touchActionPropertyName = 'msTouchAction';
+	}
+
+	setTouchAction = function setTouchAction(/* Node */ node, /* string */ action) {
+		node.style[touchActionPropertyName] = action;
+	}
+}
 
 var Moveable = declare("dojo.dnd.Moveable", [Evented], {
 	// summary:
@@ -22,6 +41,11 @@ var Moveable = declare("dojo.dnd.Moveable", [Evented], {
 		// params: Moveable.__MoveableArgs?
 		//		optional parameters
 		this.node = dom.byId(node);
+
+		if (needsTouchAction) {
+			setTouchAction(this.node, 'none');
+		}
+
 		if(!params){ params = {}; }
 		this.handle = params.handle ? dom.byId(params.handle) : null;
 		if(!this.handle){ this.handle = this.node; }
@@ -46,6 +70,11 @@ var Moveable = declare("dojo.dnd.Moveable", [Evented], {
 		// summary:
 		//		stops watching for possible move, deletes all references, so the object can be garbage-collected
 		array.forEach(this.events, function(handle){ handle.remove(); });
+
+		if (needsTouchAction) {
+			setTouchAction(this.node, '');
+		}
+
 		this.events = this.node = this.handle = null;
 	},
 

--- a/has.js
+++ b/has.js
@@ -116,6 +116,10 @@ define(["require", "module"], function(require, module){
 		has.add("pointer-events", "pointerEnabled" in window.navigator ?
 				window.navigator.pointerEnabled : "PointerEvent" in window);
 		has.add("MSPointer", window.navigator.msPointerEnabled);
+		// The "pointermove"" event is only continuously emitted in a touch environment if
+		// the target node's "touch-action"" CSS property is set to "none"
+		// https://www.w3.org/TR/pointerevents/#the-touch-action-css-property
+		has.add("touch-action", has("touch") && has("pointer-events"));
 
 		// I don't know if any of these tests are really correct, just a rough guess
 		has.add("device-width", screen.availWidth || innerWidth);


### PR DESCRIPTION
This patch checks for "touch" support and "pointer-events" - if both are present, the `touch-action` (`ms-touch-action` for older IE) CSS property is set on the node being made moveable.

With Chrome 55's introduction of pointer events, `dojo/dnd/Moveable` no longer works in an environment with both touch and pointer events (e.g. Chrome 55 on Android).

The 'pointermove' event will only be continuously emitted in a touch
environment if the target node's 'touch-action' CSS property is
set to 'none'.

Fixes [18968](https://bugs.dojotoolkit.org/ticket/18968)