### PR TITLE
Prevent changedTouches from being dereferenced on non-TouchEvent instances

### DIFF
--- a/on.js
+++ b/on.js
@@ -581,11 +581,13 @@ define(["./has!dom-addeventlistener?:./aspect", "./_base/kernel", "./sniff"], fu
 						event.rotation = 0;
 						event.scale = 1;
 					}
-					//use event.changedTouches[0].pageX|pageY|screenX|screenY|clientX|clientY|target
-					var firstChangeTouch = event.changedTouches[0];
-					for(var i in firstChangeTouch){ // use for-in, we don't need to have dependency on dojo/_base/lang here
-						delete event[i]; // delete it first to make it mutable
-						event[i] = firstChangeTouch[i];
+					if (window.TouchEvent && originalEvent instanceof TouchEvent) {
+						// use event.changedTouches[0].pageX|pageY|screenX|screenY|clientX|clientY|target
+						var firstChangeTouch = event.changedTouches[0];
+						for(var i in firstChangeTouch){ // use for-in, we don't need to have dependency on dojo/_base/lang here
+							delete event[i]; // delete it first to make it mutable
+							event[i] = firstChangeTouch[i];
+						}
 					}
 				}
 				return listener.call(this, event);

--- a/tests/unit/on.js
+++ b/tests/unit/on.js
@@ -597,10 +597,30 @@ define([
 				// threw insecure operation errors when saving an event to a closure-bound variable.
 				lastEvent = lang.mixin({}, event);
 			});
+			// Since we can't simulate invoking TouchEvents (with the current version of Chrome)
+			// we will make TouchEvent be an Event temporarily so the `on` implementation
+			// thinks that it is one for this test.
+			var originalTouchEvent = window.TouchEvent;
+			window.TouchEvent = Event;
 			on.emit(div, 'touchstart', { changedTouches: [{ pageX: 100 }] });
+			window.TouchEvent = originalTouchEvent;
 
 			assert.property(lastEvent, 'rotation');
 			assert.property(lastEvent, 'pageX');
+		});
+
+		has('touch') && (suite['DOM-specific']['touch event normalization doesn\'t happen to non-TouchEvent'] = function () {
+			var div = document.body.appendChild(document.createElement('div'));
+
+			var lastEvent;
+			on(div, 'touchstart', function (event) {
+				// Copying event properties to an object because certain versions of Firefox
+				// threw insecure operation errors when saving an event to a closure-bound variable.
+				lastEvent = lang.mixin({}, event);
+			});
+			on.emit(div, 'touchstart', { changedTouches: [{ pageX: 100 }] });
+
+			assert.isFalse(lastEvent.pageX === 100);
 		});
 	}
 

--- a/tests/unit/on.js
+++ b/tests/unit/on.js
@@ -597,7 +597,7 @@ define([
 				// threw insecure operation errors when saving an event to a closure-bound variable.
 				lastEvent = lang.mixin({}, event);
 			});
-			// Since we can't simulate invoking TouchEvents (with the current version of Chrome)
+			// Since we can't simulate invoking TouchEvents (with current browsers initTouchEvent isn't available)
 			// we will make TouchEvent be an Event temporarily so the `on` implementation
 			// thinks that it is one for this test.
 			var originalTouchEvent = window.TouchEvent;


### PR DESCRIPTION
Fixes: https://bugs.dojotoolkit.org/ticket/18895 by checking to make sure the event is truly an instance of `TouchEvent` before allowing the consultation of `changedTouches` to occur.