### PR TITLE
Fixing problem with cross domain styles

### DIFF
--- a/dom-style.js
+++ b/dom-style.js
@@ -45,10 +45,12 @@ define(["./sniff", "./dom", "./_base/window"], function(has, dom, win){
 		};
 	}else{
 		getComputedStyle = function(node){
-			var dv = node.ownerDocument.defaultView,
-				w = dv.opener ? dv : win.global.window.parent;
-			return node.nodeType == 1 /* ELEMENT_NODE*/ ?
-				w.getComputedStyle(node, null) : {};
+			if(node.nodeType === 1 /* ELEMENT_NODE*/){
+				var dv = node.ownerDocument.defaultView,
+					w = dv.opener ? dv : win.global.window;
+				return w.getComputedStyle(node, null);
+			}
+			return {};
 		};
 	}
 	style.getComputedStyle = getComputedStyle;


### PR DESCRIPTION
Fixing a few issues. 

1. Removing the reference to `window.parent` and instead directly referencing `window`. This was causing cross domain issues.
2. Moving the check for `node.nodeType` up higher because in FF `node.ownerDocument` was causing issues when `nodeType` was not `1`.