### PR TITLE
request/xhr: use fully-qualified URL in test for has('native-xhr2-blob')

### DIFF
--- a/request/xhr.js
+++ b/request/xhr.js
@@ -34,8 +34,9 @@ define([
 	has.add('native-xhr2-blob', function(){
 		if(!has('native-response-type')){ return; }
 		var x = new XMLHttpRequest();
-		// URL should be fully-qualified as XMLHTTPRequest within a Worker
-		// created from a Blob does not support relative URL paths
+		// The URL used here does not have to be reachable as the XHR's `send` method is never called.
+		// It does need to be parsable/resolvable in all cases, so it should be an absolute URL.
+		// XMLHttpRequest within a Worker created from a Blob does not support relative URL paths.
 		x.open('GET', 'https://dojotoolkit.org/', true);
 		x.responseType = 'blob';
 		// will not be set if unsupported

--- a/request/xhr.js
+++ b/request/xhr.js
@@ -34,7 +34,9 @@ define([
 	has.add('native-xhr2-blob', function(){
 		if(!has('native-response-type')){ return; }
 		var x = new XMLHttpRequest();
-		x.open('GET', '/', true);
+		// URL should be fully-qualified as XMLHTTPRequest within a Worker
+		// created from a Blob does not support relative URL paths
+		x.open('GET', 'https://dojotoolkit.org/', true);
 		x.responseType = 'blob';
 		// will not be set if unsupported
 		var responseType = x.responseType;

--- a/tests/unit/request/xhr.js
+++ b/tests/unit/request/xhr.js
@@ -8,6 +8,7 @@ define([
 	'dojo/query',
 	'require'
 ], function (registerSuite, assert, xhr, RequestTimeoutError, CancelError, all, query, require) {
+	var global = this;
 	var hasFormData = 'FormData' in this && typeof FormData === 'function';
 	var hasResponseType = typeof XMLHttpRequest !== 'undefined' &&
 		typeof new XMLHttpRequest().responseType !== 'undefined';
@@ -510,6 +511,89 @@ define([
 					handleAs: 'document'
 				}).then(function (response) {
 					assert.strictEqual(response.constructor, document.constructor);
+				});
+			}
+		},
+
+		'Web Workers': {
+			'from blob': function () {
+				if (!('Worker' in global)) {
+					this.skip('Worker is not supported');
+				}
+
+				if (!('Blob' in global)) {
+					this.skip('Blob is not supported');
+				}
+
+				if (!URL.createObjectURL) {
+					this.skip('URL.createObjectURL is not supported');
+				}
+
+				var dfd = this.async();
+				var baseUrl = location.origin + '/' + require.toUrl('testing');
+				var testUrl = location.origin + '/' + require.toUrl('./support/truthy.json');
+
+				var workerFunction = function () {
+					self.addEventListener('message', function (event) {
+						if (event.data.baseUrl) {
+							testXhr(event.data.baseUrl, event.data.testUrl);
+						}
+					});
+
+					dojoConfig = { async: true };
+
+					function testXhr(baseUrl, testUrl) {
+						var xhr = new XMLHttpRequest();
+
+						dojoConfig.baseUrl = baseUrl;
+
+						xhr.onreadystatechange = function () {
+							if (xhr.readyState === 4 && xhr.status === 200) {
+								var blob = new Blob([xhr.response], {type: 'application/javascript'});
+								var blobURL = URL.createObjectURL(blob);
+
+								importScripts(blobURL);
+
+								require([
+									'dojo/request/xhr'
+								], function(xhr) {
+									xhr.get(testUrl).then(function (response) {
+										if (response === 'true') {
+											self.postMessage('success');
+										}
+										else {
+											throw new Error(response);
+										}
+									}, function (error) {
+										throw error;
+									});
+								});
+							}
+						};
+						xhr.open('GET', baseUrl + '/dojo.js', true);
+						xhr.send();
+					}
+				};
+
+				var blob = new Blob(['(' + workerFunction.toString()+')()'], {type: 'application/javascript'});
+				var worker = new Worker(URL.createObjectURL(blob));
+
+				worker.addEventListener('error', function (error) {
+					dfd.reject(error);
+				});
+
+				worker.addEventListener('message', function (message) {
+					if (message.data === 'success') {
+						dfd.resolve();
+					}
+					else {
+						dfd.reject(message);
+					}
+				});
+
+				worker.postMessage({
+					baseUrl: baseUrl,
+					testUrl: testUrl
 				});
 			}
 		}

--- a/tests/unit/request/xhr.js
+++ b/tests/unit/request/xhr.js
@@ -517,6 +517,10 @@ define([
 
 		'Web Workers': {
 			'from blob': function () {
+				if (!('URL' in global)) {
+					this.skip('URL is not supported');
+				}
+
 				if (!('Worker' in global)) {
 					this.skip('Worker is not supported');
 				}


### PR DESCRIPTION
Fix [#18998](https://bugs.dojotoolkit.org/ticket/18998)
Use fully-qualified URL in `request/xhr`'s `has('native-xhr2-blob')`.
Relative URLs with XMLHttpRequest do not work in a Web Worker generated from a blob.