### PR TITLE
request/script: add error handler before element is appended to document

### DIFF
--- a/request/script.js
+++ b/request/script.js
@@ -35,7 +35,12 @@ define([
 		}
 
 		element.type = 'text/javascript';
-		element.src = url;
+		try {
+			element.src = url;
+		} catch(err) {
+			errorHandler && errorHandler(element);
+		}
+
 		element.id = id;
 		element.async = true;
 		element.charset = 'utf-8';


### PR DESCRIPTION
Fixes [#19016](https://bugs.dojotoolkit.org/ticket/19016)

`dojo/request/script`: add error handler before element is appended to document to ensure that any error thrown immediately when the element is appended to the document is handled.