### PR TITLE
Google Closure Compiler upgrade: Removing duplicate object keys

### DIFF
--- a/testsDOH/_base/loader/i18n-exhaustive/i18n-test/i18n-test-with-layers-and-preloads.profile.js
+++ b/testsDOH/_base/loader/i18n-exhaustive/i18n-test/i18n-test-with-layers-and-preloads.profile.js
@@ -1,6 +1,5 @@
 var profile = (function(){
 	return {
-		localeList:"ab,ab-cd-ef",
 		resourceTags:{
 			ignore: function(filename, mid){
 				return /(profile\.js|html)$/.test(filename);


### PR DESCRIPTION
Dojo 1.x uses currently the Google Closure Compiler v20160911.

It is currently impossible to upgrade the Google Closure Compiler to a newer version. The reason is — there is an incompatibility issue, when using the Google Closure Compiler to process Dojo applications: duplicate object keys.

This pull request introduces changes to the Dojo 1.x's source code that remove all the occurrences of duplicate object keys in code.