### PR TITLE
Add quotes to catch key

### DIFF
--- a/promise/Promise.js
+++ b/promise/Promise.js
@@ -104,16 +104,16 @@ define([
 			return this.then(callbackOrErrback, callbackOrErrback);
 		},
 
-        catch: function(errback){
-            // summary:
-            //		Add new errbacks to the promise. Follows ECMA specification naming.
-            // errback: Function?
-            //		Callback to be invoked when the promise is rejected.
-            // returns: dojo/promise/Promise
-            //		Returns a new promise for the result of the errback.
+		"catch": function(errback){
+		    // summary:
+		    //		Add new errbacks to the promise. Follows ECMA specification naming.
+		    // errback: Function?
+		    //		Callback to be invoked when the promise is rejected.
+		    // returns: dojo/promise/Promise
+		    //		Returns a new promise for the result of the errback.
 
-            return this.then(null, errback);
-        },
+		    return this.then(null, errback);
+		},
 
 		otherwise: function(errback){
 			// summary:


### PR DESCRIPTION
Current nightly build is failing with error:

> ```error(356) The optimizer threw an exception; the module probably contains syntax errors. module identifier: /srv/www/vhosts.d/archive.dojotoolkit.org/dojo-2017-08-22/checkout/release/demosite/dojo/promise/Promise.js; exception: (compile time:0.001s). OPTIMIZER FAILED: InternalError: invalid property id```

Add quotes to `catch` key in `Promise`.