### PR TITLE
Enable require-based global for third-party AMD loaders

### DIFF
--- a/dojo.js
+++ b/dojo.js
@@ -1942,6 +1942,10 @@
 		if(has("dojo-log-api")){
 			signal(error, makeError("defineAlreadyDefined", 0));
 		}
+		if (global.require) {
+			global.require.global = global;
+		}
+		global.define(["require"], function(require){ require.global = global; });
 		return;
 	}else{
 		global.define = def;


### PR DESCRIPTION
Because the global variable is accessed through require, ensure it is assigned if a third-party AMD loader is used.