### PR TITLE
Avoid Rhino’s global function

### DIFF
--- a/dojo.js
+++ b/dojo.js
@@ -64,7 +64,7 @@
 
 	// define global
 	var globalObject = (function(){
-		if (typeof global !== 'undefined') {
+		if (typeof global !== 'undefined' && typeof global !== 'function') {
 			// global spec defines a reference to the global object called 'global'
 			// https://github.com/tc39/proposal-global
 			// `global` is also defined in NodeJS

--- a/global.js
+++ b/global.js
@@ -1,5 +1,5 @@
 define(function(){
-    if (typeof global !== 'undefined') {
+    if (typeof global !== 'undefined' && typeof global !== 'function') {
         // global spec defines a reference to the global object called 'global'
         // https://github.com/tc39/proposal-global
         // `global` is also defined in NodeJS


### PR DESCRIPTION
Rhino exposes a global variable, `global` which does not represent the global context and can be detected by skipping over it if it is a function.