### PR TITLE
Add upload progress support to dojo/request/xhr

### DIFF
--- a/request/xhr.js
+++ b/request/xhr.js
@@ -306,6 +306,10 @@ define([
 		// withCredentials: Boolean?
 		//		For cross-site requests, whether to send credentials
 		//		or not.
+		// uploadProgress: Boolean?
+		//		Upload progress events cause preflighted requests. This
+		//		option enables upload progress event support but also
+		//		causes all requests to be pre-lighted.
 	});
 	xhr.__MethodOptions = declare(null, {
 		// method: String?

--- a/request/xhr.js
+++ b/request/xhr.js
@@ -309,7 +309,7 @@ define([
 		// uploadProgress: Boolean?
 		//		Upload progress events cause preflighted requests. This
 		//		option enables upload progress event support but also
-		//		causes all requests to be pre-lighted.
+		//		causes all requests to be preflighted.
 	});
 	xhr.__MethodOptions = declare(null, {
 		// method: String?

--- a/request/xhr.js
+++ b/request/xhr.js
@@ -116,7 +116,7 @@ define([
 			//		Canceler for deferred
 			response.xhr.abort();
 		};
-		addListeners = function(_xhr, dfd, response){
+		addListeners = function(_xhr, dfd, response, uploadProgress){
 			// summary:
 			//		Adds event listeners to the XMLHttpRequest object
 			function onLoad(evt){
@@ -143,10 +143,15 @@ define([
 			_xhr.addEventListener('error', onError, false);
 			_xhr.addEventListener('progress', onProgress, false);
 
+			if (uploadProgress && _xhr.upload) {
+				_xhr.upload.addEventListener('progress', onProgress, false);
+			}
+
 			return function(){
 				_xhr.removeEventListener('load', onLoad, false);
 				_xhr.removeEventListener('error', onError, false);
 				_xhr.removeEventListener('progress', onProgress, false);
+				_xhr.upload.removeEventListener('progress', onProgress, false);
 				_xhr = null;
 			};
 		};
@@ -193,7 +198,7 @@ define([
 			// older IE breaks point 9 in http://www.w3.org/TR/XMLHttpRequest/#the-open()-method and sends fragment, so strip it
 			url = url.split('#')[0];
 		}
-		
+
 		var remover,
 			last = function(){
 				remover && remover();
@@ -220,7 +225,7 @@ define([
 		response.getHeader = getHeader;
 
 		if(addListeners){
-			remover = addListeners(_xhr, dfd, response);
+			remover = addListeners(_xhr, dfd, response, options.uploadProgress);
 		}
 
 		// IE11 treats data: undefined different than other browsers

--- a/tests/services/request/xhr.service.js
+++ b/tests/services/request/xhr.service.js
@@ -32,7 +32,7 @@ define([
 	}
 
 	return function (request) {
-		var promise = new util.Promise(function (resolve) {
+		var dfd = new util.Promise(function (resolve) {
 			function respond(data) {
 				resolve({
 					status: 200,
@@ -60,6 +60,7 @@ define([
 				resolve(responseType(require.toUrl('./support/blob.gif'), 'image/gif'));
 				return;
 			}
+
 			if (request.serviceURL.indexOf('/responseTypeDoc') > -1) {
 				resolve(responseType(require.toUrl('./support/document.html'), 'text/html'));
 				return;
@@ -88,14 +89,18 @@ define([
 			else {
 				respond();
 			}
-		});
+		}, true);
+
+		if (request.query.simulateProgress) {
+			dfd.progress({ type: 'progress' });
+		}
 
 		var milliseconds = request.query.delay;
 		if (milliseconds) {
 			milliseconds = parseInt(milliseconds, 10);
-			promise = util.delay(promise, milliseconds);
+			dfd.promise = util.delay(dfd.promise, milliseconds);
 		}
 
-		return promise;
+		return dfd.promise;
 	};
 });

--- a/tests/services/util.js
+++ b/tests/services/util.js
@@ -7,7 +7,7 @@ define([
 	'intern/dojo/promise/Promise',
 	'intern/dojo/promise/all'
 ], function (exports, lang, array, Deferred, CancelError, DojoPromise, all) {
-	exports.Promise = function Promise(executor) {
+	exports.Promise = function Promise(executor, returnDfd) {
 		var canceler;
 		var dfd = new Deferred(function (reason) {
 			if (canceler) {
@@ -32,7 +32,7 @@ define([
 			dfd.reject(e);
 		}
 
-		return dfd.promise;
+		return returnDfd ? dfd : dfd.promise;
 	};
 
 	exports.Promise.reject = function (error) {

--- a/tests/unit/request/xhr.js
+++ b/tests/unit/request/xhr.js
@@ -199,6 +199,30 @@ define([
 				def.reject
 			);
 		},
+		'.post File with upload progress': function() {
+			if (!File) {
+				this.skip('File not available');
+			}
+			var def = this.async(),
+				str = 'foo',
+				file = new File([str], 'bar.txt', {type:'text/plain'});
+
+			var promise = xhr.post('/__services/request/xhr', {
+				data: file,
+				handleAs: 'json',
+				uploadProgress: true,
+				query: {
+					simulateProgress: true
+				},
+				headers: {
+					'Content-Type':'text/plain'
+				}
+			});
+
+			promise.then(null, def.reject, def.callback(function (progressEvent) {
+				assert.isDefined(progressEvent.xhr);
+			}));
+		},
 		'.post with query': function () {
 			var def = this.async(),
 				promise = xhr.post('/__services/request/xhr', {


### PR DESCRIPTION
The current implementation of `dojo/request/xhr` didn't support upload progress events. Unlike downloads, a listener for the `progress` event has to be added to the `XMLHttpRequest#upload` property for uploads, not the request itself. We [never actually add any events](https://github.com/dojo/dojo/blob/master/request/xhr.js#L142-L144) to the `upload` object. Unfortunately, if we just modify `dojo/request/xhr` to check for an `upload` property on the `XMLHttpRequest` to add event listeners to, this [causes all requests to be preflighted](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests).

This PR adds support for a new property on the `options` object passed to `dojo/request/xhr` that's called `uploadProgress`. Setting this property to `true` allows upload progress events to fire as expected, while also requiring the developer to consciously opt-in to preflighted requests if upload progress functionality is required.