### PR TITLE
add test for dojo/Stateful module: when we set one stateful instance to another, the watchers should work correctly

### DIFF
--- a/tests/unit/Stateful.js
+++ b/tests/unit/Stateful.js
@@ -68,6 +68,32 @@ define([
 
 				assert.isTrue(onAnyValueChange.calledTwice);
 				assert.isTrue(onFooValueChange.calledOnce);
+			},
+
+			'child watcher': function () {
+				model = new Stateful({
+					user: {
+						name: 1
+					}
+				});
+
+				var results;
+
+				model.watch("user", function(field, oldValue, newValue) {
+					newValue.watch(function(_field, _oldValue, _newValue) {
+						results = [_field, _oldValue, _newValue];
+					});
+				});
+
+				var userPet = new Stateful({
+					name: 2
+				});
+
+				model.set("user", userPet);
+
+				userPet.set("name", 3);
+
+				assert.deepEqual(results, ['name', 2, 3], 'child watcher work correctly');
 			}
 		},
 


### PR DESCRIPTION
Hello! In our project we make several improves for dojo/Stateful module.

When we write tests for that behavior, we find out that we lost child watchers on set. 
Your tests don't cover case when you use watcher on child object and then set it to the parent object.

I want to add this test case - in case if you make the same mistake.