### PR TITLE
Don’t add Content-Type unless post/put or has data

### DIFF
--- a/request/xhr.js
+++ b/request/xhr.js
@@ -96,7 +96,7 @@ define([
 				}else{
 					error = new RequestError('Unable to load ' + response.url + ' status: ' + _xhr.status +
 						' and an error in handleAs: transformation of response', response);
-    				this.reject(error);
+					this.reject(error);
 				}
 			}
 		}
@@ -188,6 +188,7 @@ define([
 		);
 		url = response.url;
 		options = response.options;
+		var hasNoData = !options.data && options.method !== 'POST' && options.method !== 'PUT';
 
 		if(has('ie') <= 10){
 			// older IE breaks point 9 in http://www.w3.org/TR/XMLHttpRequest/#the-open()-method and sends fragment, so strip it
@@ -241,7 +242,7 @@ define([
 			}
 
 			var headers = options.headers,
-				contentType = isFormData ? false : 'application/x-www-form-urlencoded';
+				contentType = (isFormData || hasNoData) ? false : 'application/x-www-form-urlencoded';
 			if(headers){
 				for(var hdr in headers){
 					if(hdr.toLowerCase() === 'content-type'){

--- a/tests/unit/request/xhr.js
+++ b/tests/unit/request/xhr.js
@@ -347,24 +347,24 @@ define([
 		},
 
 		'has Content-Type with data': function () {
-            var def = this.async();
+			var def = this.async();
 
-            xhr.post('/__services/request/xhr', {
-            	data: 'testing',
-                handleAs: 'json'
-            }).then(
-                def.callback( function (response) {
-                    assert.equal(response.headers['content-type'], 'application/x-www-form-urlencoded');
-                }),
-                def.reject
-            );
+			xhr.post('/__services/request/xhr', {
+				data: 'testing',
+				handleAs: 'json'
+			}).then(
+				def.callback( function (response) {
+					assert.equal(response.headers['content-type'], 'application/x-www-form-urlencoded');
+				}),
+				def.reject
+			);
 		},
 
 		'no Content-Type with no data': function() {
 			var def = this.async();
 
 			xhr.get('/__services/request/xhr', {
-                handleAs: 'json'
+				handleAs: 'json'
 			}).then(
 				def.callback( function (response) {
 					assert.isUndefined(response.headers['content-type']);

--- a/tests/unit/request/xhr.js
+++ b/tests/unit/request/xhr.js
@@ -346,6 +346,33 @@ define([
 			);
 		},
 
+		'has Content-Type with data': function () {
+            var def = this.async();
+
+            xhr.post('/__services/request/xhr', {
+            	data: 'testing',
+                handleAs: 'json'
+            }).then(
+                def.callback( function (response) {
+                    assert.equal(response.headers['content-type'], 'application/x-www-form-urlencoded');
+                }),
+                def.reject
+            );
+		},
+
+		'no Content-Type with no data': function() {
+			var def = this.async();
+
+			xhr.get('/__services/request/xhr', {
+                handleAs: 'json'
+			}).then(
+				def.callback( function (response) {
+					assert.isUndefined(response.headers['content-type']);
+				}),
+				def.reject
+			);
+		},
+
 		headers: function () {
 			var def = this.async();
 


### PR DESCRIPTION
Content-Type of "application/x-www-form-urlencoded" was being added to GET/HEAD requests without any data. To minimize side-effects, this is removed only when the request isn't PUT/POST and there is no data.

Tests added to check for this header under these conditions.