### PR TITLE
Remove trailing package location slash when building URL

### DIFF
--- a/dojo.js
+++ b/dojo.js
@@ -1058,7 +1058,7 @@
 			if(mapItem){
 				url = mapItem[1] + mid.substring(mapItem[3]);
 			}else if(pid){
-				url = pack.location + "/" + midInPackage;
+				url = (pack.location.slice(-1) === '/' ? pack.location.slice(0, -1) : pack.location) + "/" + midInPackage;
 			}else if(has("config-tlmSiblingOfDojo")){
 				url = "../" + mid;
 			}else{


### PR DESCRIPTION
When constructing a URL, a package location with a trailing slash will result in a double slash in the URL. For servers that cannot resolve this pattern, this results in a 404.

This code has a very minor performance impact of ~0.0000381 ms when there is a trailing slash and ~0.0000224 ms without.