### PR TITLE
Deduplicate `dojo/request/xhr` handlers call

### DIFF
--- a/request/xhr.js
+++ b/request/xhr.js
@@ -67,13 +67,6 @@ define([
 			response.data = _xhr.responseXML;
 		}
 
-		if(!error){
-			try{
-				handlers(response);
-			}catch(e){
-				error = e;
-			}
-		}
 		var handleError;
 		if(error){
 			this.reject(error);


### PR DESCRIPTION
Resolves https://bugs.dojotoolkit.org/ticket/19097. When sending requests with `dojo/request/xhr`, prevent `handlers` from being called with the response twice. This deduplication in turn allows failed responses to reject with the more useful error message from the remaining `try/catch` block.