### PR TITLE
improve performance on _base/Color.blendColors

### DIFF
--- a/_base/Color.js
+++ b/_base/Color.js
@@ -145,10 +145,10 @@ define(["./kernel", "./lang", "./array", "./config"], function(dojo, lang, Array
 		//		Blend colors end and start with weight from 0 to 1, 0.5 being a 50/50 blend,
 		//		can reuse a previously allocated Color object for the result
 		var t = obj || new Color();
-		ArrayUtil.forEach(["r", "g", "b", "a"], function(x){
-			t[x] = start[x] + (end[x] - start[x]) * weight;
-			if(x != "a"){ t[x] = Math.round(t[x]); }
-		});
+		t.r = Math.round(start.r + (end.r - start.r) * weight);
+		t.g = Math.round(start.g + (end.g - start.g) * weight);
+		t.b = Math.round(start.b + (end.b - start.b) * weight);
+		t.a = start.a + (end.a - start.a) * weight;
 		return t.sanitize();	// Color
 	};
 


### PR DESCRIPTION
Unroll the static for-loop and call the `r`, `g,` `b`, `a` properties directly, resulting in increased performance (~10ms based on testing) in the same number of lines. Testing in Chrome with the following code, this change results in average run times of 10ms to about 2-3ms.

```javascript
require(['dojo/_base/Color'], (Color) => {
	const startColor = new Color({ r: 0, g: 12, b: 220, a: 0 });
	const endColor = new Color({ r: 255, g: 255, b: 220, a: 0 });
	const weight = 10;

	const start = window.performance.now();
	for (let i = 0; i < 10000; ++i) {
		Color.blendColors(startColor, endColor, weight);
	}
	const end = window.performance.now();
	const delta = end - start;
	console.log('delta', delta);
});
```