### PR TITLE
Fix potential XSS vulnerability

### DIFF
--- a/testsDOH/_base/i18nExhaustive.js
+++ b/testsDOH/_base/i18nExhaustive.js
@@ -15,10 +15,6 @@ define([
 		"sync,,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built/i18nTest,amd",
 		"sync,,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
 		"sync,,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
-		"sync,,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,src,./i18n-test,amd",
-		"sync,,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built/i18nTest,amd",
-		"sync,,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
-		"sync,,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
 				
 		"sync,ab,src,./dojo,src,./i18n-test,legacy",
 		"sync,ab,src,./dojo,legacy-built,./built-i18n-test/152-build,legacy",
@@ -31,10 +27,6 @@ define([
 		"sync,ab,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built/i18nTest,amd",
 		"sync,ab,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
 		"sync,ab,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
-		"sync,ab,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,src,./i18n-test,amd",
-		"sync,ab,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built/i18nTest,amd",
-		"sync,ab,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
-		"sync,ab,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
 		
 		"sync,ab-cd,src,./dojo,src,./i18n-test,legacy",
 		"sync,ab-cd,src,./dojo,legacy-built,./built-i18n-test/152-build,legacy",
@@ -47,10 +39,6 @@ define([
 		"sync,ab-cd,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built/i18nTest,amd",
 		"sync,ab-cd,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
 		"sync,ab-cd,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
-		"sync,ab-cd,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,src,./i18n-test,amd",
-		"sync,ab-cd,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built/i18nTest,amd",
-		"sync,ab-cd,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
-		"sync,ab-cd,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
 
 		"sync,ab-cd-ef,src,./dojo,src,./i18n-test,legacy",
 		"sync,ab-cd-ef,src,./dojo,legacy-built,./built-i18n-test/152-build,legacy",
@@ -63,10 +51,6 @@ define([
 		"sync,ab-cd-ef,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built/i18nTest,amd",
 		"sync,ab-cd-ef,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
 		"sync,ab-cd-ef,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
-		"sync,ab-cd-ef,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,src,./i18n-test,amd",
-		"sync,ab-cd-ef,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built/i18nTest,amd",
-		"sync,ab-cd-ef,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
-		"sync,ab-cd-ef,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
 		"async,,src,./dojo,src,./i18n-test,amd",
 		"async,,src,./dojo,built,./built-i18n-test/built/i18nTest,amd",
 		"async,,src,./dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
@@ -75,10 +59,6 @@ define([
 		"async,,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built/i18nTest,amd",
 		"async,,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
 		"async,,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
-		"async,,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,src,./i18n-test,amd",
-		"async,,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built/i18nTest,amd",
-		"async,,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
-		"async,,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
 		
 		"async,ab,src,./dojo,src,./i18n-test,amd",
 		"async,ab,src,./dojo,built,./built-i18n-test/built/i18nTest,amd",
@@ -88,10 +68,6 @@ define([
 		"async,ab,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built/i18nTest,amd",
 		"async,ab,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
 		"async,ab,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
-		"async,ab,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,src,./i18n-test,amd",
-		"async,ab,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built/i18nTest,amd",
-		"async,ab,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
-		"async,ab,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
 
 		"async,ab-cd,src,./dojo,src,./i18n-test,amd",
 		"async,ab-cd,src,./dojo,built,./built-i18n-test/built/i18nTest,amd",
@@ -101,10 +77,6 @@ define([
 		"async,ab-cd,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built/i18nTest,amd",
 		"async,ab-cd,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
 		"async,ab-cd,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
-		"async,ab-cd,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,src,./i18n-test,amd",
-		"async,ab-cd,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built/i18nTest,amd",
-		"async,ab-cd,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
-		"async,ab-cd,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
 		
 		"async,ab-cd-ef,src,./dojo,src,./i18n-test,amd",
 		"async,ab-cd-ef,src,./dojo,built,./built-i18n-test/built/i18nTest,amd",
@@ -113,11 +85,7 @@ define([
 		"async,ab-cd-ef,rel,./built-i18n-test/rel/dojo,src,./i18n-test,amd",
 		"async,ab-cd-ef,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built/i18nTest,amd",
 		"async,ab-cd-ef,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
-		"async,ab-cd-ef,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd",
-		"async,ab-cd-ef,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,src,./i18n-test,amd",
-		"async,ab-cd-ef,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built/i18nTest,amd",
-		"async,ab-cd-ef,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers/i18nTest,amd",
-		"async,ab-cd-ef,cdn,http://192.168.1.114/dev/dtk/built-i18n-test/cdn/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd"];
+		"async,ab-cd-ef,rel,./built-i18n-test/rel/dojo,built,./built-i18n-test/built-with-layers-and-preloads/i18nTest,amd"];
 
 	for(var i = 0; i<testParams.length; i++){
 		doh.register("testsDOH._base.i18nExhaustive" + i, require.toUrl("dojo/main") + "/../../i18n-test/unit.html?" + testParams[i]);

--- a/testsDOH/_base/loader/i18n-exhaustive/i18n-test/unit.html
+++ b/testsDOH/_base/loader/i18n-exhaustive/i18n-test/unit.html
@@ -1,4 +1,4 @@
-<html>
+<!--<html>
 <head>
 	<style type="text/css">
 		span.pass {background-color:green}
@@ -12,6 +12,19 @@
 		//#1,,src,./dojo",src,./dtk-i18n-test
 
 		(function(){
+		var escapes = {
+			"&": "&amp;",
+			"<": "&lt;",
+			">": "&gt;",
+			"\"": "&quot;",
+			"'": "&#039;"
+		};
+		function escape(unsafe) {
+			return unsafe.replace(/[&<>"']/g, function (match) {
+				return escapes[match];
+			});
+		}
+
 		var hashInfo = location.search.substring(1),
 			options = hashInfo.split(",");
 			async = options[0]=="async" ? true : undefined,
@@ -23,7 +36,11 @@
 			testId = "async: " + async + ", locale: " + locale + ", dojo: " + dojoType + ", i18nTest: " + i18nTestType + "(" + hashInfo + ")",
 			testKind = options[6];
 
-		document.getElementById("status").innerHTML += hashInfo;
+		if ((/^http/i).test(i18nTestLocation)) {
+			return;
+		}
+
+		document.getElementById("status").innerHTML += escape(hashInfo);
 
 		function report(result){
 			require(["doh"], function(doh){
@@ -39,7 +56,7 @@
 			}else{
 				text = "<span class='fail'>FAIL</span>: " + testId + "<br>" + result;
 			}
-			document.getElementById("status").innerHTML = text;
+			document.getElementById("status").innerHTML = escape(text);
 		}	
 
 		dojoConfig = {
@@ -85,10 +102,11 @@
 		var node = document.createElement("script");
 		node.type = "text/javascript";
 		node.charset = "utf-8";
-		node.src = (/^http/.test(dojoLocation) ? dojoLocation :  "../" + dojoLocation) + "/dojo.js";
+		// If a user passes a remote URL, force it to use the local dojo
+		node.src = ((/^http/i).test(dojoLocation) ? '../dojo' :  "../" + dojoLocation) + "/dojo.js";
 console.log(node.src);
 		document.getElementsByTagName("head")[0].appendChild(node);
 		})();
 	</script>
 </body>
-</html>
+</html>-->

--- a/testsDOH/_base/loader/i18n-exhaustive/test-instructions.md
+++ b/testsDOH/_base/loader/i18n-exhaustive/test-instructions.md
@@ -59,6 +59,6 @@ The various built module and loaders are constructed by the v1.7 builder. The sh
 i18n-test/build-test-targets.sh accomplishes this task automatically.
 
 A unit test html page is constructed at i18n-test/unit.html. Given a query string, it will load a particular loader and
-exercise a particular set of modules.
+exercise a particular set of modules. Its contents must be uncommented before running the tests.
 
 Finally, the DOH test dojo/testsDOH/_base/i18nExhaustive runs all the various combinations.


### PR DESCRIPTION
* Escape text coming from URL that is used in the page
* Prevent remote scripts being executed
* Remove remote URLs from unit test file

Since this is in a DOH test that isn't used anymore nor run automatically, the threat is minimal.