### PR TITLE
Do not attempt to deep copy FormData

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"jsgi-node": "0.3.1",
 		"formidable": "1.0.17",
 		"sinon": "1.12.2",
-		"dojo": "1.14.0"
+		"dojo": "1.15.0-pre"
 	},
 	"main": "main",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"jsgi-node": "0.3.1",
 		"formidable": "1.0.17",
 		"sinon": "1.12.2",
-		"dojo": "1.15.0-pre"
+		"dojo": "1.14.0"
 	},
 	"main": "main",
 	"scripts": {
@@ -24,9 +24,13 @@
 		"test-proxy": "intern-runner config=tests/dojo.intern.proxy proxyOnly=true"
 	},
 	"description": "Dojo core is a powerful, lightweight library that makes common tasks quicker and easier. Animate elements, manipulate the DOM, and query with easy CSS syntax, all without sacrificing performance.",
-	"license" : "BSD-3-Clause OR AFL-2.1",
+	"license": "BSD-3-Clause OR AFL-2.1",
 	"bugs": "http://bugs.dojotoolkit.org/",
-	"keywords": [ "JavaScript", "Dojo", "Toolkit" ],
+	"keywords": [
+		"JavaScript",
+		"Dojo",
+		"Toolkit"
+	],
 	"homepage": "http://dojotoolkit.org/",
 	"repository": {
 		"type": "git",

--- a/request/util.js
+++ b/request/util.js
@@ -11,10 +11,10 @@ define([
 ], function(exports, RequestError, CancelError, Deferred, ioQuery, array, lang, Promise, has){
 	exports.deepCopy = function(target, source) {
 		for (var name in source) {
-			var tval = target[name], 
+			var tval = target[name],
   			    sval = source[name];
 			if (tval !== sval) {
-				if (sval && typeof sval === 'object') {
+				if (sval && typeof sval === 'object' && !(sval instanceof FormData)) {
 					if (Object.prototype.toString.call(sval) === '[object Date]') { // use this date test to handle crossing frame boundaries
 						target[name] = new Date(sval);
 					} else if (lang.isArray(sval)) {

--- a/tests/unit/request.js
+++ b/tests/unit/request.js
@@ -1,6 +1,7 @@
 define([
 	'./request/handlers',
 	'./request/registry',
+	'dojo/has!host-browser?./request/util',
 	'dojo/has!host-browser?./request/xhr',
 	'dojo/has!host-browser?./request/iframe',
 	'dojo/has!host-browser?./request/script',

--- a/tests/unit/request/util.js
+++ b/tests/unit/request/util.js
@@ -7,12 +7,13 @@ define([
 		name: 'dojo/request/util',
 
 		'deepCopy': function () {
+            var formData = new FormData();
             var object1 = {
                 apple: 0,
                 banana: {
                     weight: 52,
                     price: 100,
-                    code: "B12345", 
+                    code: "B12345",
                     purchased: new Date(2016, 0, 1)
                 },
                 cherry: 97
@@ -20,17 +21,19 @@ define([
             var object2 = {
                 banana: {
                     price: 200,
-                    code: "B98765", 
+                    code: "B98765",
                     purchased: new Date(2017, 0, 1)
                 },
+                formData: formData,
                 durian: 100
             };
             util.deepCopy(object1, object2);
 			assert.strictEqual(object1.banana.weight, 52);
 			assert.strictEqual(object1.banana.price, 200);
 			assert.strictEqual(object1.banana.code, "B98765");
+			assert.strictEqual(object1.formData, formData);
 			assert.equal(object1.banana.purchased.getTime(), new Date(2017, 0, 1).getTime());
 		}
-        
+
 	});
 });


### PR DESCRIPTION
The fix for #293 caused a breakage with `FormData` uploads, this changes leaves the fix in but skips the copy if the object an instance of `Formdata`

Resolves: #293 