### PR TITLE
request/registry: pass all arguments to matcher

### DIFF
--- a/request/registry.js
+++ b/request/registry.js
@@ -13,7 +13,7 @@ define([
 
 		while(matcher=matchers[i++]){
 			if(matcher(url, options)){
-				return matcher.request.call(null, url, options);
+				return matcher.request.apply(null, arguments);
 			}
 		}
 


### PR DESCRIPTION
Currently, request providers registered with `request/registry` only receive the first two arguments passed to `request`. This PR passes all arguments to the matcher, enabling the [`returnDeferred`](https://github.com/dojo/dojo/blob/8de7432b25af50059997d1bed051a893902c1102/request/xhr.js#L199) parameter (and any other parameters) to be handled by registered providers.

Fixes #346 