### PR TITLE
Prevent all Elements from being deep copied fixes #336

### DIFF
--- a/request/util.js
+++ b/request/util.js
@@ -18,12 +18,13 @@ define([
 		return has('native-blob') && value instanceof Blob
 	}
 	
-	function isFormElement(value) {
-		if(typeof HTMLFormElement !== 'undefined') { //all other
-			return value instanceof HTMLFormElement;
-		} else { //IE<=7
-			value.tagName === "FORM"
+	function isElement(value) {
+		if(typeof Element !== 'undefined') { //all other
+			return value instanceof Element;
 		}
+
+		//IE<=7
+		return value.nodeType === 1;
 	}
 
 	function isFormData(value) {
@@ -34,7 +35,7 @@ define([
 		return value &&
 			typeof value === 'object' &&
 			!isFormData(value) &&
-			!isFormElement(value) &&
+			!isElement(value) &&
 			!isBlob(value) &&
 			!isArrayBuffer(value)
 	}

--- a/tests/unit/request/util.js
+++ b/tests/unit/request/util.js
@@ -98,6 +98,72 @@ define([
 			} else {
 				this.skip('Do not run test if Blob not available.');
 			}
+		},
+
+		'deepCopy with Element, given Element is defined': function(){
+			if (typeof Element !== 'undefined') {
+				var element = document.createElement('span');
+				var object1 = {
+					apple: 0,
+					banana: {
+						weight: 52,
+						price: 100,
+						code: "B12345",
+						purchased: new Date(2016, 0, 1)
+					},
+					cherry: 97
+				};
+				var object2 = {
+					banana: {
+						price: 200,
+						code: "B98765",
+						purchased: new Date(2017, 0, 1)
+					},
+					element: element,
+					durian: 100
+				};
+				util.deepCopy(object1, object2);
+				assert.strictEqual(object1.banana.weight, 52);
+				assert.strictEqual(object1.banana.price, 200);
+				assert.strictEqual(object1.banana.code, "B98765");
+				assert.strictEqual(object1.element, element);
+				assert.equal(object1.banana.purchased.getTime(), new Date(2017, 0, 1).getTime());
+			} else {
+				this.skip('Do not run test if Element not available.');
+			}
+		},
+
+		'deepCopy with Element, given Element is not defined': function(){
+			if (typeof Element !== 'undefined') {
+				this.skip('Do not run test if Element is available.');
+			}
+
+			var element = {nodeType: 1, value: 'Orange'};
+			var object1 = {
+				apple: 0,
+				banana: {
+					weight: 52,
+					price: 100,
+					code: "B12345",
+					purchased: new Date(2016, 0, 1)
+				},
+				cherry: 97
+			};
+			var object2 = {
+				banana: {
+					price: 200,
+					code: "B98765",
+					purchased: new Date(2017, 0, 1)
+				},
+				element: element,
+				durian: 100
+			};
+			util.deepCopy(object1, object2);
+			assert.strictEqual(object1.banana.weight, 52);
+			assert.strictEqual(object1.banana.price, 200);
+			assert.strictEqual(object1.banana.code, "B98765");
+			assert.strictEqual(object1.element, element);
+			assert.equal(object1.banana.purchased.getTime(), new Date(2017, 0, 1).getTime());
 		}
 	});
 });


### PR DESCRIPTION
Possibly overlooking something, but I can't see why any Element would ever need to be processed by deepCopy.