### PR TITLE
Add .finally to dojo/Deferred

### DIFF
--- a/Deferred.js
+++ b/Deferred.js
@@ -301,10 +301,10 @@ define([
 					var valueOrPromise = callback();
 					if (valueOrPromise && typeof valueOrPromise.then === "function"){
 						return valueOrPromise.then(function (){
-							return new Deferred().reject(reason);
+							throw reason;
 						});
 					}
-					return new Deferred().reject(reason);
+					throw reason;
 				}
 			];
 			listener.cancel = promise.cancel;

--- a/Deferred.js
+++ b/Deferred.js
@@ -262,6 +262,63 @@ define([
 			return listener.deferred.promise;
 		};
 
+		this["finally"] = promise["finally"] = function(callback) {
+			// summary:
+			//		Add a callback to the promise that will fire whether it
+			//		resolves or rejects.
+			// description:
+			//		Conforms to ES2018's `Promise.prototype.finally`.
+			//		Add a callback to the promise that will fire whether it
+			//		resolves or rejects. No value is passed to the callback.
+			//		Returns a promise that reflects the state of the original promise,
+			//		with two exceptions:
+			//		- If the callback return a promise, the outer promise will wait
+			//		until the returned promise is resolved, then it will resolve
+			//		with the original value.
+			//		- If the callback throws an exception or returns a promise that
+			//		is rejected (or rejects later), the outer promise will reject
+			//		with the inner promise's rejection reason.
+			// callback: Function?
+			//		Callback to be invoked when the promise is resolved
+			//		or rejected. Doesn't receive any value.
+			// returns: dojo/promise/Promise
+			//		Returns a new promise that reflects the state of the original promise,
+			//		with two small exceptions (see description).
+			//
+
+			var listener = [
+				null,
+				function (value) {
+					var valueOrPromise = callback();
+					if (valueOrPromise && typeof valueOrPromise.then === "function"){
+						return valueOrPromise.then(function(){
+							return value;
+						});
+					}
+					return value;
+				},
+				function (reason) {
+					var valueOrPromise = callback();
+					if (valueOrPromise && typeof valueOrPromise.then === "function"){
+						return valueOrPromise.then(function() {
+							return new Deferred().reject(reason);
+						});
+					}
+					return new Deferred().reject(reason);
+				}
+			];
+			listener.cancel = promise.cancel;
+			listener.deferred = new Deferred(function(reason) {
+				return listener.cancel && listener.cancel(reason);
+			});
+			if (fulfilled && !waiting){
+				signalListener(listener, fulfilled, result, rejection);
+			}else{
+				waiting.push(listener);
+			}
+			return listener.deferred.promise;
+		};
+
 		this.cancel = promise.cancel = function(reason, strict){
 			// summary:
 			//		Inform the deferred it may cancel its asynchronous operation.

--- a/Deferred.js
+++ b/Deferred.js
@@ -264,13 +264,13 @@ define([
 
 		this["finally"] = promise["finally"] = function(callback) {
 			// summary:
-			//		Add a callback to the promise that will fire whether it
+			//		Add a callback to the deferred that will fire whether it
 			//		resolves or rejects.
 			// description:
 			//		Conforms to ES2018's `Promise.prototype.finally`.
-			//		Add a callback to the promise that will fire whether it
+			//		Add a callback to the deferred that will fire whether it
 			//		resolves or rejects. No value is passed to the callback.
-			//		Returns a promise that reflects the state of the original promise,
+			//		Returns a promise that reflects the state of the original deferred,
 			//		with two exceptions:
 			//		- If the callback return a promise, the outer promise will wait
 			//		until the returned promise is resolved, then it will resolve
@@ -279,10 +279,10 @@ define([
 			//		is rejected (or rejects later), the outer promise will reject
 			//		with the inner promise's rejection reason.
 			// callback: Function?
-			//		Callback to be invoked when the promise is resolved
+			//		Callback to be invoked when the deferred is resolved
 			//		or rejected. Doesn't receive any value.
 			// returns: dojo/promise/Promise
-			//		Returns a new promise that reflects the state of the original promise,
+			//		Returns a new promise that reflects the state of the original deferred,
 			//		with two small exceptions (see description).
 			//
 

--- a/Deferred.js
+++ b/Deferred.js
@@ -288,19 +288,19 @@ define([
 
 			var listener = [
 				null,
-				function (value) {
+				function (value){
 					var valueOrPromise = callback();
 					if (valueOrPromise && typeof valueOrPromise.then === "function"){
-						return valueOrPromise.then(function(){
+						return valueOrPromise.then(function (){
 							return value;
 						});
 					}
 					return value;
 				},
-				function (reason) {
+				function (reason){
 					var valueOrPromise = callback();
 					if (valueOrPromise && typeof valueOrPromise.then === "function"){
-						return valueOrPromise.then(function() {
+						return valueOrPromise.then(function (){
 							return new Deferred().reject(reason);
 						});
 					}
@@ -308,7 +308,7 @@ define([
 				}
 			];
 			listener.cancel = promise.cancel;
-			listener.deferred = new Deferred(function(reason) {
+			listener.deferred = new Deferred(function (reason){
 				return listener.cancel && listener.cancel(reason);
 			});
 			if (fulfilled && !waiting){

--- a/promise/Promise.js
+++ b/promise/Promise.js
@@ -19,6 +19,28 @@ define([
 	}, {
 		then: function(callback, errback, progback){
 			// summary:
+			//		Add new callbacks to the promise.
+			// description:
+			//		Add new callbacks to the deferred. Callbacks can be added
+			//		before or after the deferred is fulfilled.
+			// callback: Function?
+			//		Callback to be invoked when the promise is resolved.
+			//		Receives the resolution value.
+			// errback: Function?
+			//		Callback to be invoked when the promise is rejected.
+			//		Receives the rejection error.
+			// progback: Function?
+			//		Callback to be invoked when the promise emits a progress
+			//		update. Receives the progress update.
+			// returns: dojo/promise/Promise
+			//		Returns a new promise for the result of the callback(s).
+			//		This can be used for chaining many asynchronous operations.
+
+			throwAbstract();
+		},
+
+		"finally": function(callback) {
+			// summary:
 			//		Add a callback to the promise that will fire whether it
 			//		resolves or rejects.
 			// description:
@@ -40,25 +62,6 @@ define([
 			//		Returns a new promise that reflects the state of the original promise,
 			//		with two small exceptions (see description).
 			//
-
-			throwAbstract();
-		},
-
-		"finally": function(callback) {
-			// summary:
-			//		Add a callback to the promise that will fire whether it
-			//		resolves or rejects.
-			// description:
-			//		Add a callback to the promise that will fire whether it
-			//		resolves or rejects. No value is passed, no return value
-			//		is expected (the returned promise will be identical to
-			//		the parent promise).
-			// callback: Function?
-			//		Callback to be invoked when the promise is resolved
-			//		or rejected. Doesn't receive any value.
-			// returns: dojo/promise/Promise
-			//		Returns a new promise. The value/reason is not affected
-			//		by the callback.
 
 			throwAbstract();
 		},

--- a/promise/Promise.js
+++ b/promise/Promise.js
@@ -39,6 +39,25 @@ define([
 			throwAbstract();
 		},
 
+		"finally": function(callback) {
+			// summary:
+			//		Add a callback to the promise that will fire whether it
+			//		resolves or rejects.
+			// description:
+			//		Add a callback to the promise that will fire whether it
+			//		resolves or rejects. No value is passed, no return value
+			//		is expected (the returned promise will be identical to
+			//		the parent promise).
+			// callback: Function?
+			//		Callback to be invoked when the promise is resolved
+			//		or rejected. Doesn't receive any value.
+			// returns: dojo/promise/Promise
+			//		Returns a new promise. The value/reason is not affected
+			//		by the callback.
+
+			throwAbstract();
+		},
+
 		cancel: function(reason, strict){
 			// summary:
 			//		Inform the deferred it may cancel its asynchronous operation.
@@ -100,7 +119,7 @@ define([
 			//		A function that is used both as a callback and errback.
 			// returns: dojo/promise/Promise
 			//		Returns a new promise for the result of the callback/errback.
-
+			
 			return this.then(callbackOrErrback, callbackOrErrback);
 		},
 

--- a/promise/Promise.js
+++ b/promise/Promise.js
@@ -19,22 +19,27 @@ define([
 	}, {
 		then: function(callback, errback, progback){
 			// summary:
-			//		Add new callbacks to the promise.
+			//		Add a callback to the promise that will fire whether it
+			//		resolves or rejects.
 			// description:
-			//		Add new callbacks to the deferred. Callbacks can be added
-			//		before or after the deferred is fulfilled.
+			//		Conforms to ES2018's `Promise.prototype.finally`.
+			//		Add a callback to the promise that will fire whether it
+			//		resolves or rejects. No value is passed to the callback.
+			//		Returns a promise that reflects the state of the original promise,
+			//		with two exceptions:
+			//		- If the callback return a promise, the outer promise will wait
+			//		until the returned promise is resolved, then it will resolve
+			//		with the original value.
+			//		- If the callback throws an exception or returns a promise that
+			//		is rejected (or rejects later), the outer promise will reject
+			//		with the inner promise's rejection reason.
 			// callback: Function?
-			//		Callback to be invoked when the promise is resolved.
-			//		Receives the resolution value.
-			// errback: Function?
-			//		Callback to be invoked when the promise is rejected.
-			//		Receives the rejection error.
-			// progback: Function?
-			//		Callback to be invoked when the promise emits a progress
-			//		update. Receives the progress update.
+			//		Callback to be invoked when the promise is resolved
+			//		or rejected. Doesn't receive any value.
 			// returns: dojo/promise/Promise
-			//		Returns a new promise for the result of the callback(s).
-			//		This can be used for chaining many asynchronous operations.
+			//		Returns a new promise that reflects the state of the original promise,
+			//		with two small exceptions (see description).
+			//
 
 			throwAbstract();
 		},

--- a/tests/unit/Deferred.js
+++ b/tests/unit/Deferred.js
@@ -626,14 +626,14 @@ define([
 					var expectedTestValue = 1;
 					var thenExpected = {};
 					
-					deferred.resolve();
+					deferred.resolve(thenExpected);
 
 					var resultPromise = deferred.promise["finally"](function () {
 						var dfd2 = new Deferred();
 
 						setTimeout(function () {
 							testValue = expectedTestValue;
-							dfd2.resolve(thenExpected);
+							dfd2.resolve({});
 						},0);
 
 						return dfd2.promise;
@@ -696,7 +696,7 @@ define([
 					deferred.resolve();
 
 					return deferred.promise["finally"](function () {
-						return new Deferred.reject(expectedError);
+						return new Deferred().reject(expectedError);
 					}).then(function () {
 						assert.fail("Promise should not have resolved");
 					}).otherwise(function (resultError) {
@@ -710,7 +710,7 @@ define([
 					deferred.reject(new Error() /* not the expected error */);
 
 					return deferred.promise["finally"](function () {
-						return new Deferred.reject(expectedError);
+						return new Deferred().reject(expectedError);
 					}).then(function () {
 						assert.fail("Promise should not have resolved");
 					}).otherwise(function (resultError) {

--- a/tests/unit/Deferred.js
+++ b/tests/unit/Deferred.js
@@ -557,7 +557,7 @@ define([
 			'.finally': {
 				'finally() called when deferred already resolved': function () {
 					var thenExpected = {};
-					var finallyExpected = void 0; //always undefined
+					var finallyExpected = undefined;
 					
 					deferred.resolve(thenExpected);
 
@@ -573,7 +573,7 @@ define([
 
 				'finally() called when deferred is resolved later': function () {
 					var thenExpected = {};
-					var finallyExpected = void 0; //always undefined
+					var finallyExpected = undefined;
 
 					setTimeout(function () {
 						deferred.resolve(thenExpected);
@@ -591,7 +591,7 @@ define([
 
 				'finally() called when deferred already rejected': function () {
 					var otherwiseExpected = new Error();
-					var finallyExpected = void 0; //always undefined;
+					var finallyExpected = undefined;
 
 					deferred.reject(otherwiseExpected);
 
@@ -606,7 +606,7 @@ define([
 
 				'finally() called when deferred is rejected later': function () {
 					var otherwiseExpected = new Error();
-					var finallyExpected = void 0; //always undefined;
+					var finallyExpected = undefined;
 
 					setTimeout(function () {
 						deferred.reject(otherwiseExpected);
@@ -719,7 +719,7 @@ define([
 				},
 
 				'finally() is already bound to the deferred': function () {
-					var finallyExpected = void 0;
+					var finallyExpected = undefined;
 					var finallyMethod = deferred["finally"];
 
 					deferred.resolve("blah");

--- a/tests/unit/Deferred.js
+++ b/tests/unit/Deferred.js
@@ -561,12 +561,12 @@ define([
 					
 					deferred.resolve(thenExpected);
 
-					return deferred.promise["finally"](function(finallyResult) {
+					return deferred.promise["finally"](function (finallyResult) {
 						assert.equal(finallyResult, finallyExpected);
 						return "blah";
-					}).then(function(thenResult) {
+					}).then(function (thenResult) {
 						assert.equal(thenResult, thenExpected);
-					}).otherwise(function() {
+					}).otherwise(function () {
 						assert.fail("Promise should not have rejected.");
 					});
 				},
@@ -575,16 +575,16 @@ define([
 					var thenExpected = {};
 					var finallyExpected = void 0; //always undefined
 
-					setTimeout(function() {
+					setTimeout(function () {
 						deferred.resolve(thenExpected);
 					},0);
 
-					return deferred.promise["finally"](function(finallyResult) {
+					return deferred.promise["finally"](function (finallyResult) {
 						assert.equal(finallyResult, finallyExpected);
 						return "blahblah";
-					}).then(function(thenResult) {
+					}).then(function (thenResult) {
 						assert.equal(thenResult, thenExpected);
-					}).otherwise(function() {
+					}).otherwise(function () {
 						assert.fail("Promise should not have rejected.");
 					});
 				},
@@ -595,11 +595,11 @@ define([
 
 					deferred.reject(otherwiseExpected);
 
-					return deferred.promise["finally"](function(finallyResult) {
+					return deferred.promise["finally"](function (finallyResult) {
 						assert.equal(finallyResult, finallyExpected);
-					}).then(function() {
+					}).then(function () {
 						assert.fail("Promise should not have resolved.");
-					}).otherwise(function(otherwiseResult) {
+					}).otherwise(function (otherwiseResult) {
 						assert.equal(otherwiseResult, otherwiseExpected);
 					});
 				},
@@ -608,15 +608,15 @@ define([
 					var otherwiseExpected = new Error();
 					var finallyExpected = void 0; //always undefined;
 
-					setTimeout(function() {
+					setTimeout(function () {
 						deferred.reject(otherwiseExpected);
 					},0);
 
-					return deferred.promise["finally"](function(finallyResult) {
+					return deferred.promise["finally"](function (finallyResult) {
 						assert.equal(finallyResult, finallyExpected);
-					}).then(function() {
+					}).then(function () {
 						assert.fail("Promise should not have resolved.");
-					}).otherwise(function(otherwiseResult) {
+					}).otherwise(function (otherwiseResult) {
 						assert.equal(otherwiseResult, otherwiseExpected);
 					});
 				},
@@ -628,10 +628,10 @@ define([
 					
 					deferred.resolve();
 
-					var resultPromise = deferred.promise["finally"](function() {
+					var resultPromise = deferred.promise["finally"](function () {
 						var dfd2 = new Deferred();
 
-						setTimeout(function() {
+						setTimeout(function () {
 							testValue = expectedTestValue;
 							dfd2.resolve(thenExpected);
 						},0);
@@ -643,10 +643,10 @@ define([
 					assert.equal(resultPromise.isResolved(), false);
 					assert.equal(resultPromise.isFulfilled(), false);
 
-					return resultPromise.then(function(thenResult) {
+					return resultPromise.then(function (thenResult) {
 						assert.equal(testValue, expectedTestValue);
 						assert.equal(thenResult, thenExpected);
-					},function() {
+					},function () {
 						assert.fail("Promise should not have rejected");
 					});
 				},
@@ -656,10 +656,10 @@ define([
 
 					deferred.reject();
 
-					var resultPromise = deferred.promise["finally"](function() {
+					var resultPromise = deferred.promise["finally"](function () {
 						var dfd2 = new Deferred();
 
-						setTimeout(function() {
+						setTimeout(function () {
 							dfd2.reject(expectedError);
 						},0);
 
@@ -669,9 +669,9 @@ define([
 					assert.equal(resultPromise.isRejected(), false);
 					assert.equal(resultPromise.isFulfilled(), false);
 
-					return resultPromise.then(function() {
+					return resultPromise.then(function () {
 						assert.fail("Promise should not have resolved.");
-					},function(resultError) {
+					},function (resultError) {
 						assert.equal(resultError, expectedError);
 					});
 				},
@@ -681,11 +681,11 @@ define([
 
 					deferred.resolve();
 
-					return deferred.promise["finally"](function() {
+					return deferred.promise["finally"](function () {
 						throw expectedError;
-					}).then(function() {
+					}).then(function () {
 						assert.fail("Promise should not have resolved.");
-					}).otherwise(function(resultError) {
+					}).otherwise(function (resultError) {
 						assert.equal(resultError, expectedError);
 					});
 				},
@@ -695,11 +695,11 @@ define([
 
 					deferred.resolve();
 
-					return deferred.promise["finally"](function() {
+					return deferred.promise["finally"](function () {
 						return new Deferred.reject(expectedError);
-					}).then(function() {
+					}).then(function () {
 						assert.fail("Promise should not have resolved");
-					}).otherwise(function(resultError) {
+					}).otherwise(function (resultError) {
 						assert.equal(resultError, expectedError);
 					});
 				},
@@ -709,11 +709,11 @@ define([
 
 					deferred.reject(new Error() /* not the expected error */);
 
-					return deferred.promise["finally"](function() {
+					return deferred.promise["finally"](function () {
 						return new Deferred.reject(expectedError);
-					}).then(function() {
+					}).then(function () {
 						assert.fail("Promise should not have resolved");
-					}).otherwise(function(resultError) {
+					}).otherwise(function (resultError) {
 						assert.equal(resultError, expectedError);
 					});
 				},
@@ -724,7 +724,7 @@ define([
 
 					deferred.resolve("blah");
 
-					return finallyMethod(function(finallyResult) {
+					return finallyMethod(function (finallyResult) {
 						assert.equal(finallyResult, finallyExpected)
 						return "blah";
 					});


### PR DESCRIPTION
This implements ES2018 `finally` in dojo/Deferred.

Includes comprehensive tests in tests/unit/Deferred.js (all passing).

See #351 for discussion - this opts for option (1).