### PR TITLE
Implement ES2018 Promise.prototype.finally in dojo/promise/Promise

### DIFF
--- a/promise/Promise.js
+++ b/promise/Promise.js
@@ -92,6 +92,49 @@ define([
 			throwAbstract();
 		},
 
+		"finally": function(callback) {
+			// summary:
+			//		Add a callback to the promise that will fire whether it
+			//		resolves or rejects.
+			// description:
+			//		Conforms to ES2018's `Promise.prototype.finally`.
+			//		Add a callback to the promise that will fire whether it
+			//		resolves or rejects. No value is passed to the callback.
+			//		Returns a promise that reflects the state of the original promise,
+			//		with two exceptions:
+			//		- If the callback return a promise, the outer promise will wait
+			//		until the returned promise is resolved, then it will resolve
+			//		with the original value.
+			//		- If the callback throws an exception or returns a promise that
+			//		is rejected (or rejects later), the outer promise will reject
+			//		with the inner promise's rejection reason.
+			// callback: Function?
+			//		Callback to be invoked when the promise is resolved
+			//		or rejected. Doesn't receive any value.
+			// returns: dojo/promise/Promise
+			//		Returns a new promise that reflects the state of the original promise,
+			//		with two small exceptions (see description).
+			//
+
+			return this.then(function (value){
+				var valueOrPromise = callback();
+				if (valueOrPromise && typeof valueOrPromise.then === "function"){
+					return valueOrPromise.then(function (){
+						return value;
+					});
+				}
+				return value;
+			}, function(reason) {
+				var valueOrPromise = callback();
+				if (valueOrPromise && typeof valueOrPromise.then === "function"){
+					return valueOrPromise.then(function (){
+						throw reason;
+					});
+				}
+				throw reason;
+			});
+		},
+
 		always: function(callbackOrErrback){
 			// summary:
 			//		Add a callback to be invoked when the promise is resolved

--- a/tests/unit/promise/Promise.js
+++ b/tests/unit/promise/Promise.js
@@ -75,6 +75,178 @@ define([
 			var deferred = new Deferred();
 			var expectedPromise = deferred.promise;
 			assert.strictEqual(expectedPromise.traceRejected(), expectedPromise);
+		},
+
+		'finally() called when deferred already resolved': function () {
+			var deferred = new Deferred();
+			var thenExpected = {};
+			var finallyExpected = undefined;
+			
+			deferred.resolve(thenExpected);
+
+			return deferred.promise["finally"](function (finallyResult) {
+				assert.equal(finallyResult, finallyExpected);
+				return "blah";
+			}).then(function (thenResult) {
+				assert.equal(thenResult, thenExpected);
+			})["catch"](function () {
+				assert.fail("Promise should not have rejected.");
+			});
+		},
+
+		'finally() called when deferred is resolved later': function () {
+			var deferred = new Deferred();
+			var thenExpected = {};
+			var finallyExpected = undefined;
+
+			setTimeout(function () {
+				deferred.resolve(thenExpected);
+			},0);
+
+			return deferred.promise["finally"](function (finallyResult) {
+				assert.equal(finallyResult, finallyExpected);
+				return "blahblah";
+			}).then(function (thenResult) {
+				assert.equal(thenResult, thenExpected);
+			})["catch"](function () {
+				assert.fail("Promise should not have rejected.");
+			});
+		},
+
+		'finally() called when deferred already rejected': function () {
+			var deferred = new Deferred();
+			var expected = new Error();
+			var finallyExpected = undefined;
+
+			deferred.reject(expected);
+
+			return deferred.promise["finally"](function (finallyResult) {
+				assert.equal(finallyResult, finallyExpected);
+			}).then(function () {
+				assert.fail("Promise should not have resolved.");
+			})["catch"](function (result) {
+				assert.equal(result, expected);
+			});
+		},
+
+		'finally() called when deferred is rejected later': function () {
+			var deferred = new Deferred();
+			var otherwiseExpected = new Error();
+			var finallyExpected = undefined;
+
+			setTimeout(function () {
+				deferred.reject(otherwiseExpected);
+			},0);
+
+			return deferred.promise["finally"](function (finallyResult) {
+				assert.equal(finallyResult, finallyExpected);
+			}).then(function () {
+				assert.fail("Promise should not have resolved.");
+			})["catch"](function (otherwiseResult) {
+				assert.equal(otherwiseResult, otherwiseExpected);
+			});
+		},
+
+		'finally() holds up call chain when chaining from a resolved promise and returning a promise that will resolve': function () {
+			var deferred = new Deferred();
+			var testValue = 0;
+			var expectedTestValue = 1;
+			var thenExpected = {};
+			
+			deferred.resolve(thenExpected);
+
+			var resultPromise = deferred.promise["finally"](function () {
+				var dfd2 = new Deferred();
+
+				setTimeout(function () {
+					testValue = expectedTestValue;
+					dfd2.resolve({});
+				},0);
+
+				return dfd2.promise;
+			});
+
+			//shouldn't be resolved until after the setTimeout fires.
+			assert.equal(resultPromise.isResolved(), false);
+			assert.equal(resultPromise.isFulfilled(), false);
+
+			return resultPromise.then(function (thenResult) {
+				assert.equal(testValue, expectedTestValue);
+				assert.equal(thenResult, thenExpected);
+			},function () {
+				assert.fail("Promise should not have rejected");
+			});
+		},
+
+		'finally() holds up call chain correctly when chaining from a rejected promise and returning a promise that will reject': function () {
+			var deferred = new Deferred();
+			var expectedError = new Error();
+
+			deferred.reject();
+
+			var resultPromise = deferred.promise["finally"](function () {
+				var dfd2 = new Deferred();
+
+				setTimeout(function () {
+					dfd2.reject(expectedError);
+				},0);
+
+				return dfd2.promise;
+			});
+
+			assert.equal(resultPromise.isRejected(), false);
+			assert.equal(resultPromise.isFulfilled(), false);
+
+			return resultPromise.then(function () {
+				assert.fail("Promise should not have resolved.");
+			},function (resultError) {
+				assert.equal(resultError, expectedError);
+			});
+		},
+
+		'finally() returns rejected promise if callback throws exception': function () {
+			var deferred = new Deferred();
+			var expectedError = new Error();
+
+			deferred.resolve();
+
+			return deferred.promise["finally"](function () {
+				throw expectedError;
+			}).then(function () {
+				assert.fail("Promise should not have resolved.");
+			})["catch"](function (resultError) {
+				assert.equal(resultError, expectedError);
+			});
+		},
+
+		'finally() returns rejected promise if chained off resolved promise and callback returns rejected promise': function () {
+			var deferred = new Deferred();
+			var expectedError = new Error();
+
+			deferred.resolve();
+
+			return deferred.promise["finally"](function () {
+				return new Deferred().reject(expectedError);
+			}).then(function () {
+				assert.fail("Promise should not have resolved");
+			})["catch"](function (resultError) {
+				assert.equal(resultError, expectedError);
+			});
+		},
+
+		'finally() returns rejected promise if chained off rejected promise and callback returns rejected promise': function () {
+			var deferred = new Deferred();
+			var expectedError = new Error();
+
+			deferred.reject(new Error() /* not the expected error */);
+
+			return deferred.promise["finally"](function () {
+				return new Deferred().reject(expectedError);
+			}).then(function () {
+				assert.fail("Promise should not have resolved");
+			})["catch"](function (resultError) {
+				assert.equal(resultError, expectedError);
+			});
 		}
 	});
 });


### PR DESCRIPTION
Supersedes https://github.com/dojo/dojo/pull/352

Implementing ES2018's `Promise.prototype.finally` in dojo/promise/Promise instead of dojo/Deferred because:
- Implementing in dojo/Deferred leaves an API hole -- we have an abstract `"finally"` method in dojo/promise/Promise that is left without an implementation in Promise instances built in dojo/_base/Deferred. So `new baseDeferred().promise.finally(function(){})` would throw the "abstract" `TypeError`. Implementing in dojo/promise/Promise allows all Deferreds that use this Promise class to inherit `finally` in their `promise` objects -- dojo/Deferred, dojo/_base/Deferred, and even any (hypothetical?) custom Deferred classes built by users.
- `finally` can be implemented directly in terms of `then` with _reduced_ complexity over the previous implementation - at runtime, computationally, and in the source. 

Includes comprehensive, passing unit tests in tests/unit/promise/Promise.js.