### PR TITLE
i18n: improve functionality when dojo-v1x-i18n-Api is false

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -379,7 +379,7 @@ define(["./_base/kernel", "require", "./has", "./_base/array", "./_base/config",
 										var bundle = rollup[p],
 											match = p.match(/(.+)\/([^\/]+)$/),
 											bundleName, bundlePath;
-											
+
 											// If there is no match, the bundle is not a regular bundle from an AMD layer.
 											if (!match){continue;}
 
@@ -432,8 +432,8 @@ define(["./_base/kernel", "require", "./has", "./_base/array", "./_base/config",
 												if(requiredBundles.length){
 													preloadingAddLock();
 													contextRequire(requiredBundles, function(){
-														// requiredBundles was constructed by forEachLocale so it contains locales from 
-														// less specific to most specific. 
+														// requiredBundles was constructed by forEachLocale so it contains locales from
+														// less specific to most specific.
 														// the loop starts with the most specific locale, the last one.
 														for(var i = requiredBundles.length - 1; i >= 0 ; i--){
 															bundle = lang.mixin(lang.clone(bundle), arguments[i]);
@@ -619,6 +619,12 @@ define(["./_base/kernel", "require", "./has", "./_base/array", "./_base/config",
 				}
 			);
 			return result;
+		};
+	}
+	else {
+		thisModule.getLocalization = function(moduleName, bundleName, locale){
+			var key = moduleName.replace(/\./g, '/') + '/nls/' + bundleName + '/' + (locale || config.locale);
+			return this.cache[key];
 		};
 	}
 


### PR DESCRIPTION
This change adds a simplified implementation of `i18n.getLocalization` when `dojo-v1x-i18n-Api` is `false` that allows `dojo/i18n` to retain a good amount of functionality. Without this patch `dijit/Calendar` throws an error when calling the non-existent `i18n.getLocalization` method. With this patch, if Dojo is used with pure AMD syntax `dijit/Calendar` will load the necessary CLDR data and work correctly.

Fixes #378