### PR TITLE
dojo/_base/array: wrap calls to new Function in csp-restriction checks

### DIFF
--- a/_base/array.js
+++ b/_base/array.js
@@ -5,9 +5,13 @@ define(["./kernel", "../has", "./lang"], function(dojo, has, lang){
 	// our old simple function builder stuff
 	var cache = {}, u;
 
-	function buildFn(fn){
-		return cache[fn] = new Function("item", "index", "array", fn); // Function
+	var buildFn;
+	if(!has("csp-restrictions")){
+		buildFn = function (fn){
+			return cache[fn] = new Function("item", "index", "array", fn); // Function
+		};
 	}
+
 	// magic snippet: if(typeof fn == "string") fn = cache[fn] || buildFn(fn);
 
 	// every & some
@@ -17,7 +21,14 @@ define(["./kernel", "../has", "./lang"], function(dojo, has, lang){
 		return function(a, fn, o){
 			var i = 0, l = a && a.length || 0, result;
 			if(l && typeof a == "string") a = a.split("");
-			if(typeof fn == "string") fn = cache[fn] || buildFn(fn);
+			if(typeof fn == "string"){
+				if(has("csp-restrictions")){
+					throw new TypeError("callback must be a function");
+				}
+				else{
+					fn = cache[fn] || buildFn(fn);
+				}
+			}
 			if(o){
 				for(; i < l; ++i){
 					result = !fn.call(o, a[i], i, a);
@@ -241,7 +252,14 @@ define(["./kernel", "../has", "./lang"], function(dojo, has, lang){
 
 			var i = 0, l = arr && arr.length || 0;
 			if(l && typeof arr == "string") arr = arr.split("");
-			if(typeof callback == "string") callback = cache[callback] || buildFn(callback);
+			if(typeof callback == "string"){
+				if(has("csp-restrictions")){
+					throw new TypeError("callback must be a function");
+				}
+				else{
+					callback = cache[callback] || buildFn(callback);
+				}
+			}
 			if(thisObject){
 				for(; i < l; ++i){
 					callback.call(thisObject, arr[i], i, arr);
@@ -279,7 +297,14 @@ define(["./kernel", "../has", "./lang"], function(dojo, has, lang){
 			// TODO: why do we have a non-standard signature here? do we need "Ctr"?
 			var i = 0, l = arr && arr.length || 0, out = new (Ctr || Array)(l);
 			if(l && typeof arr == "string") arr = arr.split("");
-			if(typeof callback == "string") callback = cache[callback] || buildFn(callback);
+			if(typeof callback == "string"){
+				if(has("csp-restrictions")){
+					throw new TypeError("callback must be a function");
+				}
+				else{
+					callback = cache[callback] || buildFn(callback);
+				}
+			}
 			if(thisObject){
 				for(; i < l; ++i){
 					out[i] = callback.call(thisObject, arr[i], i, arr);
@@ -319,7 +344,14 @@ define(["./kernel", "../has", "./lang"], function(dojo, has, lang){
 			// TODO: do we need "Ctr" here like in map()?
 			var i = 0, l = arr && arr.length || 0, out = [], value;
 			if(l && typeof arr == "string") arr = arr.split("");
-			if(typeof callback == "string") callback = cache[callback] || buildFn(callback);
+			if(typeof callback == "string"){
+				if(has("csp-restrictions")){
+					throw new TypeError("callback must be a function");
+				}
+				else{
+					callback = cache[callback] || buildFn(callback);
+				}
+			}
 			if(thisObject){
 				for(; i < l; ++i){
 					value = arr[i];

--- a/tests/unit/_base/array.js
+++ b/tests/unit/_base/array.js
@@ -1,8 +1,11 @@
 define([
 	'intern!object',
 	'intern/chai!assert',
+	'dojo/has',
 	'../../../_base/array'
-], function (registerSuite, assert, array) {
+], function (registerSuite, assert, has, array) {
+	var hasCspRestrictions = has('csp-restrictions');
+
 	registerSuite({
 		name: 'dojo/_base/array',
 
@@ -83,7 +86,7 @@ define([
 
 			// FIXME: test forEach w/ a NodeList()?
 			'string callback': function () {
-				// Test using strings as callback", which accept the parameters with
+				// Test using strings as callback, which accept the parameters with
 				// the names "item", "index" and "array"!
 				var foo = [128, 'bbb', 512];
 
@@ -177,6 +180,38 @@ define([
 						}
 					})
 				);
+			},
+
+			'string callback': function () {
+				// Test using strings as callback, which accept the parameters with
+				// the names "item", "index" and "array"!
+				var foo = [128, 'bbb', 512];
+
+				// Test that the variable "item" contains the value of each item.
+				var obj = {
+					_res: ''
+				};
+				assert(array.every(foo, 'this._res += item; return true', obj));
+				assert.strictEqual(obj._res, '128bbb512');
+
+				// Test that the variable "index" contains each index.
+				obj._res = [];
+				assert(array.every(foo, 'this._res.push(index); return true', obj));
+				assert.deepEqual(obj._res, [0,1,2]);
+
+				// Test that the variable "array" always contains the entire array.
+				obj._res = [];
+				assert(array.every(foo, 'this._res.push(array); return true', obj));
+				assert.deepEqual(obj._res, [
+					[128, 'bbb', 512],
+					[128, 'bbb', 512],
+					[128, 'bbb', 512]
+				]);
+
+				// Catch undefined variable usage (I used to use "i" :-)).
+				assert.throws(function () {
+					array.every(foo, 'this._res += arr[i];', obj);
+				}, /.*/, 'every on undefined variable');
 			}
 		},
 
@@ -245,6 +280,38 @@ define([
 						return false;
 					})
 				);
+			},
+
+			'string callback': function () {
+				// Test using strings as callback, which accept the parameters with
+				// the names "item", "index" and "array"!
+				var foo = [128, 'bbb', 512];
+
+				// Test that the variable "item" contains the value of each item.
+				var obj = {
+					_res: ''
+				};
+				assert(array.some(foo, 'this._res += item; return item === "bbb"', obj));
+				assert.strictEqual(obj._res, '128bbb');
+
+				// Test that the variable "index" contains each index.
+				obj._res = [];
+				assert(array.some(foo, 'this._res.push(index); return item === "bbb"', obj));
+				assert.deepEqual(obj._res, [0,1]);
+
+				// Test that the variable "array" always contains the entire array.
+				obj._res = [];
+				assert.isFalse(array.some(foo, 'this._res.push(array); return item === "ZZZ"', obj));
+				assert.deepEqual(obj._res, [
+					[128, 'bbb', 512],
+					[128, 'bbb', 512],
+					[128, 'bbb', 512]
+				]);
+
+				// Catch undefined variable usage (I used to use "i" :-)).
+				assert.throws(function () {
+					array.some(foo, 'this._res += arr[i];', obj);
+				}, /.*/, 'some on undefined variable');
 			}
 		},
 
@@ -299,21 +366,127 @@ define([
 					}),
 					[]
 				);
+			},
+
+			'string callback': function () {
+				// Test using strings as callback, which accept the parameters with
+				// the names "item", "index" and "array"!
+				var foo = [128, 'bbb', 512];
+
+				// Test that the variable "item" contains the value of each item.
+				var obj = {
+					_res: ''
+				};
+				array.filter(foo, 'this._res += item', obj);
+				assert.strictEqual(obj._res, '128bbb512');
+
+				// Test that the variable "index" contains each index.
+				obj._res = [];
+				array.filter(foo, 'this._res.push(index)', obj);
+				assert.deepEqual(obj._res, [0,1,2]);
+
+				// Test that the variable "array" always contains the entire array.
+				obj._res = [];
+				array.filter(foo, 'this._res.push(array)', obj);
+				assert.deepEqual(obj._res, [
+					[128, 'bbb', 512],
+					[128, 'bbb', 512],
+					[128, 'bbb', 512]
+				]);
+
+				// Catch undefined variable usage (I used to use "i" :-)).
+				assert.throws(function () {
+					array.filter(foo, 'this._res += arr[i];', obj);
+				}, /.*/, 'filter on undefined variable');
 			}
 		},
 
-		'.map': function () {
-			assert.deepEqual(
-				array.map(function () { return true; }, []),
-				[]
-			);
+		'.map': {
+			array: function () {
+				assert.deepEqual(
+					array.map(function () { return true; }, []),
+					[]
+				);
 
-			assert.deepEqual(
-				array.map(['cat', 'dog', 'mouse'], function (item, index) {
-					return index+1;
-				}),
-				[1, 2, 3]
-			);
+				assert.deepEqual(
+					array.map(['cat', 'dog', 'mouse'], function (item, index) {
+						return index+1;
+					}),
+					[1, 2, 3]
+				);
+			},
+
+			'string callback': function () {
+				// Test using strings as callback, which accept the parameters with
+				// the names "item", "index" and "array"!
+				var foo = [128, 'bbb', 512];
+
+				// Test that the variable "item" contains the value of each item.
+				var obj = {
+					_res: ''
+				};
+				array.map(foo, 'this._res += item', obj);
+				assert.strictEqual(obj._res, '128bbb512');
+
+				// Test that the variable "index" contains each index.
+				obj._res = [];
+				array.map(foo, 'this._res.push(index)', obj);
+				assert.deepEqual(obj._res, [0,1,2]);
+
+				// Test that the variable "array" always contains the entire array.
+				obj._res = [];
+				array.map(foo, 'this._res.push(array)', obj);
+				assert.deepEqual(obj._res, [
+					[128, 'bbb', 512],
+					[128, 'bbb', 512],
+					[128, 'bbb', 512]
+				]);
+
+				// Catch undefined variable usage (I used to use "i" :-)).
+				assert.throws(function () {
+					array.map(foo, 'this._res += arr[i];', obj);
+				}, /.*/, 'map on undefined variable');
+			}
+		},
+
+		'csp-restrictions': {
+			setup: function () {
+				has.add('csp-restrictions', true);
+			},
+
+			teardown: function () {
+				has.add('csp-restrictions', hasCspRestrictions);
+			},
+
+			'.forEach': function () {
+				assert.throws(function () {
+					array.forEach([1], 'abc');
+				});
+			},
+
+			'.every': function () {
+				assert.throws(function () {
+					array.every([1], 'abc');
+				});
+			},
+
+			'.some': function () {
+				assert.throws(function () {
+					array.some([1], 'abc');
+				});
+			},
+
+			'.filter': function () {
+				assert.throws(function () {
+					array.filter([1], 'abc');
+				});
+			},
+
+			'.map': function () {
+				assert.throws(function () {
+					array.map([1], 'abc');
+				});
+			}
 		}
 	});
 });


### PR DESCRIPTION
* `dojo/_base/array`: add `has('csp-restricions')` guards on all potential calls to `new Function`
* `tests/unit/_base/array`:
  * add string callback tests to all array methods that support it
  * add CSP restriction tests

Closes #384 