### PR TITLE
Change block-scoped functions to named function expressions

### DIFF
--- a/_base/fx.js
+++ b/_base/fx.js
@@ -587,13 +587,13 @@ define(["./kernel", "./config", /*===== "./declare", =====*/ "./lang", "../Event
 					prop.end = prop.end(n);
 				}
 				var isColor = (p.toLowerCase().indexOf("color") >= 0);
-				function getStyle(node, p){
+				var getStyle = function getStyle(node, p){
 					// domStyle.get(node, "height") can return "auto" or "" on IE; this is more reliable:
 					var v = { height: node.offsetHeight, width: node.offsetWidth }[p];
 					if(v !== undefined){ return v; }
 					v = style.get(node, p);
 					return (p == "opacity") ? +v : (isColor ? v : parseFloat(v));
-				}
+				};
 				if(!("end" in prop)){
 					prop.end = getStyle(n, p);
 				}else if(!("start" in prop)){

--- a/i18n.js
+++ b/i18n.js
@@ -402,7 +402,7 @@ define(["./_base/kernel", "require", "./has", "./_base/array", "./_base/config",
 
 										if(loc !== locale){
 											// capture some locale variables
-											function improveBundle(bundlePath, bundleName, bundle, localized){
+											var improveBundle = function improveBundle(bundlePath, bundleName, bundle, localized){
 												// locale was not flattened and we've fallen back to a less-specific locale that was flattened
 												// for example, we had a flattened 'fr', a 'fr-ca' is available for at least this bundle, and
 												// locale==='fr-ca'; therefore, we must improve the bundle as retrieved from the rollup by
@@ -447,7 +447,7 @@ define(["./_base/kernel", "require", "./has", "./_base/array", "./_base/config",
 													// this is the best possible (definitely not a perfect match), accept it
 													cache[cacheId(bundlePath, bundleName, locale, require)] = bundle;
 												}
-											}
+											};
 											improveBundle(bundlePath, bundleName, bundle, localized);
 										}
 									}

--- a/parser.js
+++ b/parser.js
@@ -532,10 +532,10 @@ define([
 			//	- scripts: if specified, collects <script type="dojo/..."> type nodes from children
 			var inherited = options.inherited;
 			if(!inherited){
-				function findAncestorAttr(node, attr){
+				var findAncestorAttr = function findAncestorAttr(node, attr){
 					return (node.getAttribute && node.getAttribute(attr)) ||
 						(node.parentNode && findAncestorAttr(node.parentNode, attr));
-				}
+				};
 
 				inherited = {
 					dir: findAncestorAttr(root, "dir"),

--- a/touch.js
+++ b/touch.js
@@ -107,7 +107,7 @@ function(dojo, aspect, dom, domClass, lang, on, has, mouse, domReady, win){
 			if(!clicksInited){
 				clicksInited = true;
 
-				function updateClickTracker(e){
+				var updateClickTracker = function updateClickTracker(e){
 					if(useTarget){
 						clickTracker = dom.isDescendant(
 							win.doc.elementFromPoint(
@@ -120,7 +120,7 @@ function(dojo, aspect, dom, domClass, lang, on, has, mouse, domReady, win){
 							Math.abs((e.changedTouches ? e.changedTouches[0].pageX - win.global.pageXOffset : e.clientX) - clickX) <= clickDx &&
 							Math.abs((e.changedTouches ? e.changedTouches[0].pageY - win.global.pageYOffset : e.clientY) - clickY) <= clickDy;
 					}
-				}
+				};
 
 				win.doc.addEventListener(moveType, function(e){
 					if(mouse.isRight(e)){
@@ -149,7 +149,7 @@ function(dojo, aspect, dom, domClass, lang, on, has, mouse, domReady, win){
 						//some attributes can be on the Touch object, not on the Event:
 						//http://www.w3.org/TR/touch-events/#touch-interface
 						var src = (e.changedTouches) ? e.changedTouches[0] : e;
-						function createMouseEvent(type){
+						var createMouseEvent = function createMouseEvent(type){
 							//create the synthetic event.
 							//http://www.w3.org/TR/DOM-Level-3-Events/#widl-MouseEvent-initMouseEvent
 							var evt = document.createEvent("MouseEvents");
@@ -171,7 +171,7 @@ function(dojo, aspect, dom, domClass, lang, on, has, mouse, domReady, win){
 								null //related target
 							);
 							return evt;
-						}
+						};
 						var mouseDownEvt = createMouseEvent("mousedown");
 						var mouseUpEvt = createMouseEvent("mouseup");
 						var clickEvt = createMouseEvent("click");
@@ -187,7 +187,7 @@ function(dojo, aspect, dom, domClass, lang, on, has, mouse, domReady, win){
 					}
 				}, true);
 
-				function stopNativeEvents(type){
+				var stopNativeEvents = function stopNativeEvents(type){
 					win.doc.addEventListener(type, function(e){
 						// Stop native events when we emitted our own click event.  Note that the native click may occur
 						// on a different node than the synthetic click event was generated on.  For example,
@@ -223,7 +223,7 @@ function(dojo, aspect, dom, domClass, lang, on, has, mouse, domReady, win){
 							}
 						}
 					}, true);
-				}
+				};
 
 				stopNativeEvents("click");
 


### PR DESCRIPTION
With the addition of block scope to ES6 it has become impractical for tools like Google Closure Compiler to handle block-scoped functions in pre-ES6 code and they are flagged as errors.

This PR ensures that `dojo` can still be built if the build profile sets `optimizeOptions.languageIn` to `'ECMASCRIPT3'` with versions of Google Closure Compiler that support ES6. See dojo/util#83