### PR TITLE
json5/parse.js: enclose 'default' property in quotes

### DIFF
--- a/json5/README.md
+++ b/json5/README.md
@@ -13,6 +13,7 @@ tsc lib/parse.js lib/unicode.js lib/util.js --allowJs --module ES6 --outDir dojo
 to be made
 * Copy the files from the `json5/dojo` folder to the `dojo/json5` folder
 * Manual updates:
+  * IMPORTANT: wrap the `lexStates` object property `default:` in quotes => `'default':`
   * convert indentation to tabs in each module
   * remove any trailing commas
   * convert each module to AMD syntax

--- a/json5/parse.js
+++ b/json5/parse.js
@@ -87,7 +87,7 @@ define([
 		return c;
 	}
 	var lexStates = {
-		default: function () {
+		'default': function () {
 			switch (c) {
 				case '\t':
 				case '\v':


### PR DESCRIPTION
'default' is an ES6 reserved keyword. When used as a property name it must be enclosed in quotes.

This should fix build errors with the message: `OPTIMIZER FAILED: InternalError: invalid property id`