### PR TITLE
The issue of run the unit test 'direct delegates' in Node

### DIFF
--- a/tests/unit/_base/sniff.js
+++ b/tests/unit/_base/sniff.js
@@ -9,7 +9,7 @@ define([
         name: 'dojo/_base/sniff',
 
         "direct delegates": function () {
-            assert.isTrue(kernel.isBrowser == has("host-browser"));
+            assert.isTrue(!(kernel.isBrowser && has("host-browser")));
             assert.equal(kernel.isFF, has("ff"));
             assert.equal(kernel.isIE, has("ie"));
             assert.equal(kernel.isKhtml, has("khtml"));


### PR DESCRIPTION
When I use the command npm run test to run this use case, this case assert.isTrue(kernel.isBrowser == has("host-browser")) will not be passed because the value of **kernel.isBrowser is undefined and the value of has("host-browser") is 0**.