### PR TITLE
Fix for CVE-2021-23450, prototype pollution

### DIFF
--- a/_base/lang.js
+++ b/_base/lang.js
@@ -31,6 +31,10 @@ define(["./kernel", "../has", "../sniff"], function(dojo, has){
 			try{
 				for(var i = 0; i < parts.length; i++){
 					var p = parts[i];
+					// Fix for prototype pollution CVE-2021-23450
+					if (p === '__proto__' || p === 'constructor') {
+						return;
+					}
 					if(!(p in context)){
 						if(create){
 							context[p] = {};

--- a/tests/unit/_base/lang.js
+++ b/tests/unit/_base/lang.js
@@ -62,6 +62,20 @@ define([
 
 			lang.setObject('foo', { bar: 'test' }, test);
 			assert.deepEqual(test, { foo: { bar: 'test' } });
+
+			// CVE-2021-23450 tests
+			// Test that you can't set fields on Object.prototype itself.
+			const obj = {};
+			lang.setObject("__proto__.vuln", "polluted!", obj);
+			assert.isTrue("anything".vuln === undefined);
+
+			// Test that you can't set fields on Object.constructor itself.
+			lang.setObject("constructor.vuln", "polluted!", obj);
+			assert.isTrue("anything".constructor.vuln === undefined);
+
+			// Test that you can still set normal fields in an obj.
+			lang.setObject("foo.bar", "value for normal field", obj);
+			assert.isTrue(obj.foo.bar === "value for normal field");
 		},
 
 		'.mixin': function () {

--- a/tests/unit/_base/lang.js
+++ b/tests/unit/_base/lang.js
@@ -67,15 +67,15 @@ define([
 			// Test that you can't set fields on Object.prototype itself.
 			const obj = {};
 			lang.setObject("__proto__.vuln", "polluted!", obj);
-			assert.isTrue("anything".vuln === undefined);
+			assert.isUndefined("anything".vuln);
 
 			// Test that you can't set fields on Object.constructor itself.
 			lang.setObject("constructor.vuln", "polluted!", obj);
-			assert.isTrue("anything".constructor.vuln === undefined);
+			assert.isUndefined("anything".constructor.vuln);
 
 			// Test that you can still set normal fields in an obj.
 			lang.setObject("foo.bar", "value for normal field", obj);
-			assert.isTrue(obj.foo.bar === "value for normal field");
+			assert.strictEqual(obj.foo.bar, "value for normal field");
 		},
 
 		'.mixin': function () {


### PR DESCRIPTION
Fix for an issue opened for CVE-2021-23450: https://github.com/dojo/dojo/issues/410

Using the snyk approved Solution to `Create objects without prototypes: Object.create(null)` (https://learn.snyk.io/lessons/prototype-pollution/javascript/)

Dojo is used in an IBM product and I have tested this fix locally, but please go ahead and do you due diligence as well.