### PR TITLE
Address CVE-2021-23450

### DIFF
--- a/_base/lang.js
+++ b/_base/lang.js
@@ -31,6 +31,9 @@ define(["./kernel", "../has", "../sniff"], function(dojo, has){
 			try{
 				for(var i = 0; i < parts.length; i++){
 					var p = parts[i];
+					if (p === "__proto__") {
+						return;
+					}
 					if(!(p in context)){
 						if(create){
 							context[p] = {};


### PR DESCRIPTION
By excluding the "__proto__" property from being an accessible part, eliminate the vulnerability reported as CVE-2021-23450.