### PR TITLE
Fix for CVE-2021-23450, prototype pollution

### DIFF
--- a/_base/lang.js
+++ b/_base/lang.js
@@ -31,6 +31,10 @@ define(["./kernel", "../has", "../sniff"], function(dojo, has){
 			try{
 				for(var i = 0; i < parts.length; i++){
 					var p = parts[i];
+					// Fix for prototype pollution CVE-2021-23450
+					if (p === '__proto__' || p === 'constructor') {
+						return;
+					}
 					if(!(p in context)){
 						if(create){
 							context[p] = {};

--- a/tests/unit/_base/lang.js
+++ b/tests/unit/_base/lang.js
@@ -62,6 +62,20 @@ define([
 
 			lang.setObject('foo', { bar: 'test' }, test);
 			assert.deepEqual(test, { foo: { bar: 'test' } });
+
+			// CVE-2021-23450 tests
+			// Test that you can't set fields on Object.prototype itself.
+			const obj = {};
+			lang.setObject("__proto__.vuln", "polluted!", obj);
+			assert.isUndefined("anything".vuln);
+
+			// Test that you can't set fields on Object.constructor itself.
+			lang.setObject("constructor.vuln", "polluted!", obj);
+			assert.isUndefined("anything".constructor.vuln);
+
+			// Test that you can still set normal fields in an obj.
+			lang.setObject("foo.bar", "value for normal field", obj);
+			assert.strictEqual(obj.foo.bar, "value for normal field");
 		},
 
 		'.mixin': function () {


### PR DESCRIPTION
Fix for an issue opened for [CVE-2021-23450](https://github.com/advisories/GHSA-m8gw-hjpr-rjv7): #410

Excludes `proto` and `constructor` from being accessed. Also adds unit tests.