### PR TITLE
Prevent Form element from being deep copied when form is from an iframe

### DIFF
--- a/request/util.js
+++ b/request/util.js
@@ -27,8 +27,8 @@ define([
 		return value.nodeType === 1;
 	}
 
-	function isFormData(value) {
-		return has('native-formdata') && value instanceof FormData;
+	function isFormData(value) { 
+		return has('native-formdata') && (value instanceof FormData || (typeof value.tagName === 'string' && value.tagName.toLowerCase() === 'form'));
 	}
 
 	function shouldDeepCopy(value) {


### PR DESCRIPTION
When using  deepCopy in request/util with a form element that is from an iframe (not the same context) an error ocurrs: Maximum call stack size exceeded issue in deepCopy in request/util module