### PR TITLE
reject prototype segment in getProp to block setObject pollution

### DIFF
--- a/_base/lang.js
+++ b/_base/lang.js
@@ -32,7 +32,7 @@ define(["./kernel", "../has", "../sniff"], function(dojo, has){
 				for(var i = 0; i < parts.length; i++){
 					var p = parts[i];
 					// Fix for prototype pollution CVE-2021-23450
-					if (p === '__proto__' || p === 'constructor') {
+					if (p === '__proto__' || p === 'constructor' || p === 'prototype') {
 						return;
 					}
 					if(!(p in context)){

--- a/tests/unit/_base/lang.js
+++ b/tests/unit/_base/lang.js
@@ -73,6 +73,10 @@ define([
 			lang.setObject("constructor.vuln", "polluted!", obj);
 			assert.isUndefined("anything".constructor.vuln);
 
+			// Test that you can't reach a prototype through a named global.
+			lang.setObject("Object.prototype.vuln", "polluted!");
+			assert.isUndefined(({}).vuln);
+
 			// Test that you can still set normal fields in an obj.
 			lang.setObject("foo.bar", "value for normal field", obj);
 			assert.strictEqual(obj.foo.bar, "value for normal field");


### PR DESCRIPTION
The CVE-2021-23450 guard in getProp rejects `__proto__` and `constructor` but not `prototype`, so `setObject("Object.prototype.vuln", x)` still walks to a real prototype through any named global constructor and pollutes it. Rejecting the `prototype` segment alongside the existing two closes that route; no internal caller passes `prototype` as a path segment.