### PR TITLE
guard __proto__ key in json5 parse to prevent prototype pollution

### DIFF
--- a/json5/parse.js
+++ b/json5/parse.js
@@ -743,6 +743,14 @@ define([
 			if (Array.isArray(parent_1)) {
 				parent_1.push(value);
 			}
+			else if (key === '__proto__') {
+				Object.defineProperty(parent_1, key, {
+					value: value,
+					writable: true,
+					enumerable: true,
+					configurable: true
+				});
+			}
 			else {
 				parent_1[key] = value;
 			}

--- a/tests/unit/json5.js
+++ b/tests/unit/json5.js
@@ -52,6 +52,13 @@ define([
 
 				'parses nested objects': function () {
 					assert.deepEqual(json5.parse('{a:{b:2}}'), {a: {b: 2}});
+				},
+
+				'parses "__proto__" property names without polluting the prototype': function () {
+					var value = json5.parse('{"__proto__":{"polluted":true}}');
+					assert.deepEqual(value['__proto__'], {polluted: true});
+					assert.strictEqual(Object.getPrototypeOf(value), Object.prototype);
+					assert.isUndefined(({}).polluted);
 				}
 			},
 


### PR DESCRIPTION
The bundled JSON5 parser sets object members with `parent_1[key] = value` in `push()` (json5/parse.js), so a `"__proto__"` member reassigns the result object's prototype instead of becoming an own property. dojo/parser feeds `data-dojo-props` through `json5.parse`, so attribute markup like `{"__proto__":{"x":1}}` reaches it.

Same defect as CVE-2022-46175; using `Object.defineProperty` for that one key matches the json5 2.2.2 fix and keeps normal nested parsing untouched.
