### PR TITLE
guard __proto__ key in Stateful.set hash branch

### DIFF
--- a/Stateful.js
+++ b/Stateful.js
@@ -105,7 +105,7 @@ return declare("dojo.Stateful", null, {
 		// If an object is used, iterate through object
 		if(typeof name === "object"){
 			for(var x in name){
-				if(name.hasOwnProperty(x) && x !="_watchCallbacks"){
+				if(name.hasOwnProperty(x) && x !="_watchCallbacks" && x !="__proto__"){
 					this.set(x, name[x]);
 				}
 			}

--- a/tests/unit/Stateful.js
+++ b/tests/unit/Stateful.js
@@ -116,6 +116,13 @@ define([
 				// stateObj1 watchers should not be copied to stateObj2
 				assert.isTrue(onValueChange.calledOnce);
 				handle.unwatch();
+			},
+
+			'hashed value does not reassign the prototype': function () {
+				var stateObj = new Stateful();
+				stateObj.set(JSON.parse('{"__proto__":{"injected":"yes"}}'));
+				assert.notEqual(Object.getPrototypeOf(stateObj).injected, 'yes');
+				assert.equal(typeof stateObj.get, 'function');
 			}
 		},
 


### PR DESCRIPTION
Stateful.set() iterates an object argument and assigns each member to the instance (Stateful.js:107). A `"__proto__"` key reaches `this["__proto__"] = value` and reassigns the instance prototype rather than setting a property. JSON.parse creates an own enumerable `__proto__`, so populating a model from parsed data (postscript -> set(params)) triggers it.

The loop already skips _watchCallbacks; skipping __proto__ the same way blocks the reassignment without affecting normal nested set/get.